### PR TITLE
Add magdrop3bh to the supported Neo-Geo list.

### DIFF
--- a/gamelist.txt
+++ b/gamelist.txt
@@ -1,6 +1,6 @@
 This list contains all games supported by FB Alpha.
 
-1446 games supported in total; X = excluded from build; D = included in debug build only; NW = not working
+1447 games supported in total; X = excluded from build; D = included in debug build only; NW = not working
 
   name		  status  full name						  parent	  year	  company	  hardware	  remarks
 +---------------+-------+-------------------------------------------------------+---------------+-------+---------------+---------------+---------------------------------------+
@@ -578,6 +578,7 @@ This list contains all games supported by FB Alpha.
 | mgcrystl	|  	| Magical Crystals (World, 92/01/10)			| 		| 1991	| Kaneko	| Kaneko 16-bit	| 					|
 | magdrop2	|  	| Magical Drop II					| 		| 1996	| Data East Corp| Neo Geo	| 					|
 | magdrop3	|  	| Magical Drop III					| 		| 1997	| Data East Corp| Neo Geo	| 					|
+| magdrop3bh	|  	| Magical Drop III (Secret Character Hack)		| magdrop3	| 1997	| hack		| Neo Geo	| 					|
 | maglord	|  	| Magician Lord (set 1)					| 		| 1990	| Alpha Denshi C| Neo Geo	| 					|
 | maglordh	|  	| Magician Lord (set 2)					| maglord	| 1990	| Alpha Denshi C| Neo Geo	| 					|
 | ttmahjng	|  	| Mahjong						| 		| 1980	| Taito		| Route 16	| 					|

--- a/src/burn/neogeo/d_neogeo.cpp
+++ b/src/burn/neogeo/d_neogeo.cpp
@@ -5935,6 +5935,39 @@ struct BurnDriver BurnDrvkof97pls = {
 };
 
 
+// Magical Drop III (Secret Character Hack)
+// Enable all hidden characters - hack by GSC2007
+
+static struct BurnRomInfo magdrop3bhRomDesc[] = {
+	{ "233-p1bh.p1", 	0x100000, 0x80bfe2a9, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+
+	{ "233-s1.s1",    	0x020000, 0x7399e68a, 2 | BRF_GRA },           //  1 Text layer tiles
+
+	{ "233-c1.c1",    	0x400000, 0x65e3f4c4, 3 | BRF_GRA },           //  2 Sprite data
+	{ "233-c2.c2",    	0x400000, 0x35dea6c9, 3 | BRF_GRA },           //  3
+	{ "233-c3.c3",    	0x400000, 0x0ba2c502, 3 | BRF_GRA },           //  4
+	{ "233-c4.c4",    	0x400000, 0x70dbbd6d, 3 | BRF_GRA },           //  5
+
+	{ "233-m1.m1",    	0x020000, 0x5beaf34e, 4 | BRF_ESS | BRF_PRG }, //  6 Z80 code
+
+	{ "233-v1.v1",    	0x400000, 0x58839298, 5 | BRF_SND },           //  7 Sound data
+	{ "233-v2.v2",    	0x080000, 0xd5e30df4, 5 | BRF_SND },           //  8
+};
+
+STDROMPICKEXT(magdrop3bh, magdrop3bh, neogeo)
+STD_ROM_FN(magdrop3bh)
+
+struct BurnDriver BurnDrvmagdrop3bh = {
+	"magdrop3bh", "magdrop3", "neogeo", "1997",
+	"Magical Drop III (Secret Character Hack)\0", NULL, "hack", "Neo Geo",
+	L"Magical Drop III\0\u30DE\u30B8\u30AB\u30EB\u30C9\u30ED\u30C3\u30D7III (Secret Character Hack)\0", NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_SNK_NEOGEO,
+	NULL, magdrop3bhRomInfo, magdrop3bhRomName, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, 0, NULL, NULL, NULL, &NeoRecalcPalette,
+	304, 224, 4, 3
+};
+
+
 // Magical Drop III
 
 static struct BurnRomInfo magdrop3RomDesc[] = {


### PR DESCRIPTION
magdrop3bh is a hack of magdrop3 which automatically unlocks several secret playable characters and enables the Hard difficulty for non-JP regions.