### PR TITLE
capcom: use older QSound z80 code for less overhead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ PERL = 1
 # Profile Guided Optimization : 0, YES, APPLY
 PROFILE ?= 0
 
+# Use latest code of FBNEO for QSound emulation in cp
+QSOUND_FBNEO ?= 0 #
+
 # Choose emulation cores
 #BUILD_A68K = 1
 #BUILD_C68K = 1
@@ -166,7 +169,7 @@ depobj	+=	\
 		\
 		cps.o cps_config.o cps_draw.o cps_mem.o cps_obj.o cps_pal.o cps_run.o \
 		cps2_crpt.o cps_rw.o cps_scr.o cpsr.o cpsrd.o \
-		cpst.o ctv.o ps.o ps_m.o ps_z.o qs.o qs_c.o qs_z.o \
+		cpst.o ctv.o ps.o ps_m.o ps_z.o qs.o qs_z.o \
 		kabuki.o \
 		\
 		neogeo.o neo_run.o neo_decrypt.o neo_text.o neo_sprite.o neo_palette.o neo_upd4990a.o \
@@ -196,6 +199,12 @@ depobj	+=	\
 		#dec_aud.o dec_misc.o dec_vid.o \
 
 		#i8039.o m6502.o m6502_intf.o nec.o sh2.o z80.o z80daisy.o cz80.o \
+
+ifeq ($(QSOUND_FBNEO),1)
+depobj	+=	qs_c_neo.o
+else
+depobj	+=	qs_c.o
+endif
 
 autobj += $(depobj)
 
@@ -299,6 +308,10 @@ DEF = -DCPUTYPE=$(CPUTYPE) -DBUILD_SDL -DUSE_SPEEDHACKS -DOOPSWARE_FIX
 
 ifdef SPECIALBUILD
 	DEF += -DSPECIALBUILD=$(SPECIALBUILD)
+endif
+
+ifeq ($(QSOUND_FBNEO),1)
+	DEF += -DUSE_QSOUND_FBNEO
 endif
 
 ifdef	DEBUG

--- a/src/burn/capcom/cps.h
+++ b/src/burn/capcom/cps.h
@@ -1,71 +1,46 @@
 // CPS ----------------------------------
 #include "burnint.h"
-#include "m68000_intf.h"
-#include "z80_intf.h"
 
 #include "msm6295.h"
-#include "eeprom.h"
+#include "eeprom_93cxx.h"
 #include "timer.h"
 
 // Maximum number of beam-synchronized interrupts to check
 #define MAX_RASTER 10
 
-extern UINT32 CpsMProt[4];									// Mprot changes
-extern UINT32 CpsBID[3];										// Board ID changes
+extern unsigned int CpsMProt[4];									// Mprot changes
+extern unsigned int CpsBID[3];										// Board ID changes
 
 // cps.cpp
-extern INT32 Cps;														// 1 = CPS1, 2 = CPS2, 3 = CPS CHanger
-extern INT32 Cps1Qs;
-extern INT32 Cps1DisablePSnd;
-extern INT32 Cps2DisableQSnd;
-extern INT32 nCPS68KClockspeed;
-extern INT32 nCpsCycles;												// Cycles per frame
-extern INT32 nCpsZ80Cycles;
-extern UINT8 *CpsGfx;  extern UINT32 nCpsGfxLen;		// All the graphics
-extern UINT8 *CpsRom;  extern UINT32 nCpsRomLen;		// Program Rom (as in rom)
-extern UINT8 *CpsCode; extern UINT32 nCpsCodeLen;		// Program Rom (decrypted)
-extern UINT8 *CpsZRom; extern UINT32 nCpsZRomLen;		// Z80 Roms
-extern          INT8 *CpsQSam; extern UINT32 nCpsQSamLen;		// QSound Sample Roms
-extern UINT8 *CpsAd;   extern UINT32 nCpsAdLen;		// ADPCM Data
-extern UINT32 nCpsGfxScroll[4];								// Offset to Scroll tiles
-extern UINT32 nCpsGfxMask;									// Address mask
-extern UINT8* CpsStar;
-INT32 CpsInit();
-INT32 Cps2Init();
-INT32 CpsExit();
-INT32 CpsLoadTiles(UINT8 *Tile,INT32 nStart);
-INT32 CpsLoadTilesByte(UINT8 *Tile,INT32 nStart);
-INT32 CpsLoadTilesForgottn(INT32 nStart);
-INT32 CpsLoadTilesForgottnu(INT32 nStart);
-INT32 CpsLoadTilesPang(UINT8 *Tile,INT32 nStart);
-INT32 CpsLoadTilesSf2ebbl(UINT8 *Tile, INT32 nStart);
-INT32 CpsLoadTilesSf2b(UINT8 *Tile, INT32 nStart);
-INT32 CpsLoadTilesSf2koryuExtra(UINT8 *Tile, INT32 nStart);
-INT32 CpsLoadTilesHack160(INT32 nStart);
-INT32 CpsLoadTilesHack160Alt(INT32 nStart);
-INT32 CpsLoadTilesSf2koryu(INT32 nStart);
-INT32 CpsLoadTilesSf2stt(INT32 nStart);
-INT32 CpsLoadTilesSf2mdt(INT32 nStart);
-INT32 CpsLoadTilesSf2mdta(INT32 nStart);
-INT32 CpsLoadTilesSf2ceuab3(INT32 nStart);
-INT32 CpsLoadTilesSf2ceeabl(INT32 nStart);
-INT32 CpsLoadTilesSf2ceuab7(INT32 nStart);
-INT32 CpsLoadTilesSf2ebbl3(INT32 nStart);
-INT32 CpsLoadTilesFcrash(INT32 nStart);
-INT32 CpsLoadTilesCawingbl(INT32 nStart);
-INT32 CpsLoadTilesCaptcommb(INT32 nStart);
-INT32 CpsLoadTilesDinopic(INT32 nStart);
-INT32 CpsLoadTilesDinopic4(INT32 nStart);
-INT32 CpsLoadTilesSlampic(INT32 nStart);
-INT32 CpsLoadTilesKodb(INT32 nStart);
-INT32 CpsLoadTilesWonder3b(INT32 nStart);
-INT32 CpsLoadTilesPang3r1a(INT32 nStart);
-INT32 CpsLoadStars(UINT8 *pStar, INT32 nStart);
-INT32 CpsLoadStarsByte(UINT8 *pStar, INT32 nStart);
-INT32 CpsLoadStarsForgottnAlt(UINT8 *pStar, INT32 nStart);
-INT32 Cps2LoadTiles(UINT8 *Tile,INT32 nStart);
-INT32 Cps2LoadTilesSIM(UINT8 *Tile,INT32 nStart);
-INT32 Cps2LoadTilesGigaman2(UINT8 *Tile, UINT8 *pSrc);
+extern int Cps;														// 1 = CPS1, 2 = CPS2, 3 = CPS CHanger
+extern int Cps1Qs;
+extern int Cps1Pic;
+extern int nCPS68KClockspeed;
+extern int nCpsCycles;												// Cycles per frame
+extern int nCpsZ80Cycles;
+extern unsigned char *CpsGfx;  extern unsigned int nCpsGfxLen;		// All the graphics
+extern unsigned char *CpsRom;  extern unsigned int nCpsRomLen;		// Program Rom (as in rom)
+extern unsigned char *CpsCode; extern unsigned int nCpsCodeLen;		// Program Rom (decrypted)
+extern unsigned char *CpsZRom; extern unsigned int nCpsZRomLen;		// Z80 Roms
+extern          char *CpsQSam; extern unsigned int nCpsQSamLen;		// QSound Sample Roms
+extern unsigned char *CpsAd;   extern unsigned int nCpsAdLen;		// ADPCM Data
+extern unsigned int nCpsGfxScroll[4];								// Offset to Scroll tiles
+extern unsigned int nCpsGfxMask;									// Address mask
+extern unsigned char* CpsStar;
+int CpsInit();
+int Cps2Init();
+int CpsExit();
+int CpsLoadTiles(unsigned char *Tile,int nStart);
+int CpsLoadTilesByte(unsigned char *Tile,int nStart);
+int CpsLoadTilesPang(unsigned char *Tile,int nStart);
+int CpsLoadTilesHack160(unsigned char *Tile,int nStart);
+int CpsLoadTilesBootleg(unsigned char *Tile, int nStart);
+int CpsLoadTilesCaptcomb(unsigned char *Tile, int nStart);
+int CpsLoadTilesPunipic2(unsigned char *Tile, int nStart);
+int CpsLoadStars(unsigned char *pStar, int nStart);
+int CpsLoadStarsByte(unsigned char *pStar, int nStart);
+int Cps2LoadTiles(unsigned char *Tile,int nStart);
+int Cps2LoadTilesSIM(unsigned char *Tile,int nStart);
 
 // cps_config.h
 #define CPS_B_01		0
@@ -97,9 +72,6 @@ INT32 Cps2LoadTilesGigaman2(UINT8 *Tile, UINT8 *pSrc);
 #define HACK_B_1		26
 #define HACK_B_2		27
 #define HACK_B_3		28
-#define HACK_B_4		29
-#define HACK_B_5		30
-#define HACK_B_6		31
 
 #define GFXTYPE_SPRITES		(1<<0)
 #define GFXTYPE_SCROLL1		(1<<1)
@@ -108,225 +80,195 @@ INT32 Cps2LoadTilesGigaman2(UINT8 *Tile, UINT8 *pSrc);
 #define GFXTYPE_STARS		(1<<4)
 
 #define mapper_LWCHR		0
-#define mapper_LW621		1
-#define mapper_DM620		2
-#define mapper_ST24M1		3
-#define mapper_DM22A		4
-#define mapper_DAM63B		5
-#define mapper_ST22B		6
-#define mapper_TK22B		7
-#define mapper_WL24B		8
-#define mapper_S224B		9
-#define mapper_YI24B		10
-#define mapper_AR24B		11
-#define mapper_AR22B		12
-#define mapper_O224B		13
-#define mapper_MS24B		14
-#define mapper_CK24B		15
-#define mapper_NM24B		16
-#define mapper_CA24B		17
-#define mapper_CA22B		18
-#define mapper_STF29		19
-#define mapper_RT24B		20
-#define mapper_RT22B		21
-#define mapper_KD29B		22
-#define mapper_CC63B		23
-#define mapper_KR63B		24
-#define mapper_S9263B		25
-#define mapper_VA63B		26
-#define mapper_VA22B		27
-#define mapper_Q522B		28
-#define mapper_TK263B		29
-#define mapper_CD63B		30
-#define mapper_PS63B		31
-#define mapper_MB63B		32
-#define mapper_QD22B		33
-#define mapper_QD63B		34
-#define mapper_TN2292		35
-#define mapper_RCM63B		36
-#define mapper_PKB10B		37
-#define mapper_pang3		38
-#define mapper_sfzch		39
-#define mapper_cps2		40
-#define mapper_frog		41
-extern void SetGfxMapper(INT32 MapperId);
-extern INT32 GfxRomBankMapper(INT32 Type, INT32 Code);
-extern void SetCpsBId(INT32 CpsBId, INT32 bStars);
+#define mapper_DM620		1
+#define mapper_ST24M1		2
+#define mapper_DM22A		3
+#define mapper_ST22B		4
+#define mapper_TK22B		5
+#define mapper_WL24B		6
+#define mapper_S224B		7
+#define mapper_YI24B		8
+#define mapper_AR24B		9
+#define mapper_AR22B		10
+#define mapper_O224B		11
+#define mapper_MS24B		12
+#define mapper_CK24B		13
+#define mapper_NM24B		14
+#define mapper_CA24B		15
+#define mapper_CA22B		16
+#define mapper_STF29		17
+#define mapper_RT24B		18
+#define mapper_RT22B		19
+#define mapper_KD29B		20
+#define mapper_CC63B		21
+#define mapper_KR63B		22
+#define mapper_S9263B		23
+#define mapper_VA63B		24
+#define mapper_Q522B		25
+#define mapper_TK263B		26
+#define mapper_CD63B		27
+#define mapper_PS63B		28
+#define mapper_MB63B		29
+#define mapper_QD22B		30
+#define mapper_qadj		31
+#define mapper_qtono2		32
+#define mapper_RCM63B		33
+#define mapper_pnickj		34
+#define mapper_pang3		35
+#define mapper_sfzch		36
+#define mapper_cps2		37
+#define mapper_frog		38
+extern void SetGfxMapper(int MapperId);
+extern int GfxRomBankMapper(int Type, int Code);
+extern void SetCpsBId(int CpsBId, int bStars);
 
 // cps_pal.cpp
-extern UINT32* CpsPal;										// Hicolor version of palette
-extern INT32 nCpsPalCtrlReg;
-extern INT32 bCpsUpdatePalEveryFrame;
-INT32 CpsPalInit();
-INT32 CpsPalExit();
-INT32 CpsPalUpdate(UINT8 *pNewPal);
+extern unsigned int* CpsPal;										// Hicolor version of palette
+extern unsigned int* CpsObjPal;										// Pointer to lagged obj palette
+extern int nLagObjectPalettes;										// Lag object palettes by one frame if non-zero
+int CpsPalInit();
+int CpsPalExit();
+int CpsPalUpdate(unsigned char *pNewPal,int bRecalcAll);
+int CpsStarPalUpdate(unsigned char* pNewPal, int nLayer, int bRecalcAll);
 
 // cps_mem.cpp
-extern UINT8 *CpsRam90;
-extern UINT8 *CpsZRamC0,*CpsZRamF0;
-extern UINT8 *CpsSavePal;
-extern UINT8 *CpsRam708,*CpsReg,*CpsFrg;
-extern UINT8 *CpsSaveReg[MAX_RASTER + 1];
-extern UINT8 *CpsSaveFrg[MAX_RASTER + 1];
-extern UINT8 *CpsRamFF;
-void CpsMapObjectBanks(INT32 nBank);
-INT32 CpsMemInit();
-INT32 CpsMemExit();
-INT32 CpsAreaScan(INT32 nAction,INT32 *pnMin);
-
-typedef INT32 (*CpsMemScanCallback)(INT32, INT32*);
-extern CpsMemScanCallback CpsMemScanCallbackFunction;
+extern unsigned char *CpsRam90;
+extern unsigned char *CpsZRamC0,*CpsZRamF0;
+extern unsigned char *CpsSavePal;
+extern unsigned char *CpsRam708,*CpsReg,*CpsFrg;
+extern unsigned char *CpsSaveReg[MAX_RASTER + 1];
+extern unsigned char *CpsSaveFrg[MAX_RASTER + 1];
+extern unsigned char *CpsRamFF;
+void CpsMapObjectBanks(int nBank);
+int CpsMemInit();
+int CpsMemExit();
+int CpsAreaScan(int nAction,int *pnMin);
 
 // cps_run.cpp
-extern UINT8 CpsReset;
-extern UINT8 Cpi01A, Cpi01C, Cpi01E;
-extern INT32 nIrqLine50, nIrqLine52;								// The scanlines at which the interrupts are triggered
-extern INT32 nCpsNumScanlines;
-extern INT32 Cps1VBlankIRQLine;
-extern INT32 CpsDrawSpritesInReverse;
-INT32 CpsRunInit();
-INT32 CpsRunExit();
-INT32 Cps1Frame();
-INT32 Cps2Frame();
-typedef INT32 (*CpsRunInitCallback)();
-extern CpsRunInitCallback CpsRunInitCallbackFunction;
-typedef INT32 (*CpsRunExitCallback)();
-extern CpsRunExitCallback CpsRunExitCallbackFunction;
-typedef INT32 (*CpsRunResetCallback)();
-extern CpsRunResetCallback CpsRunResetCallbackFunction;
-typedef void (*CpsRunFrameStartCallback)();
-extern CpsRunFrameStartCallback CpsRunFrameStartCallbackFunction;
-typedef void (*CpsRunFrameMiddleCallback)();
-extern CpsRunFrameMiddleCallback CpsRunFrameMiddleCallbackFunction;
-typedef void (*CpsRunFrameEndCallback)();
-extern CpsRunFrameEndCallback CpsRunFrameEndCallbackFunction;
+extern unsigned char CpsReset;
+extern unsigned char Cpi01A, Cpi01C, Cpi01E;
+extern int nIrqLine50, nIrqLine52;								// The scanlines at which the interrupts are triggered
+extern int CpsDrawSpritesInReverse;
+int CpsRunInit();
+int CpsRunExit();
+int Cps1Frame();
+int Cps2Frame();
 
-inline static UINT8* CpsFindGfxRam(INT32 nAddr,INT32 nLen)
+inline static unsigned char* CpsFindGfxRam(int nAddr,int nLen)
 {
   nAddr&=0xffffff; // 24-bit bus
   if (nAddr>=0x900000 && nAddr+nLen<=0x930000) return CpsRam90+nAddr-0x900000;
   return NULL;
 }
 
-inline static void GetPalette(INT32 nStart, INT32 nCount)
-{
-	// Update Palette (Ghouls points to the wrong place on boot up I think)
-	INT32 nPal = (BURN_ENDIAN_SWAP_INT16(*((UINT16*)(CpsReg + 0x0A))) << 8) & 0xFFFC00;
-	
-	UINT8* Find = CpsFindGfxRam(nPal, 0xc00 << 1);
-	if (Find) {
-		memcpy(CpsSavePal + (nStart << 10), Find + (nStart << 10), nCount << 10);
-	}
-}
-
 // cps_rw.cpp
 // Treble Winner - Added INP(1FD) for sf2ue
-#define CPSINPSET INP(000) INP(001) INP(006) INP(007) INP(008) INP(010) INP(011) INP(012) INP(018) INP(019) INP(01B) INP(020) INP(021) INP(029) INP(176) INP(177) INP(179) INP(186) INP(1fd)
+#define CPSINPSET INP(000) INP(001) INP(006) INP(007) INP(008) INP(010) INP(011) INP(012) INP(018) INP(019) INP(020) INP(021) INP(029) INP(176) INP(177) INP(179) INP(186) INP(1fd)
 
 // prototype for input bits
-#define INP(nnn) extern UINT8 CpsInp##nnn[8];
+#define INP(nnn) extern unsigned char CpsInp##nnn[8];
 CPSINPSET
 #undef  INP
 
-#define INP(nnn) extern UINT8 Inp##nnn;
+#define INP(nnn) extern unsigned char Inp##nnn;
 CPSINPSET
 #undef  INP
 
 #define CPSINPEX INP(c000) INP(c001) INP(c002) INP(c003)
 
-#define INP(nnnn) extern UINT8 CpsInp##nnnn[8];
+#define INP(nnnn) extern unsigned char CpsInp##nnnn[8];
 CPSINPEX
 #undef  INP
 
 // For the Forgotten Worlds analog controls
-extern UINT16 CpsInp055, CpsInp05d;
-extern UINT16 CpsInpPaddle1, CpsInpPaddle2;
+extern unsigned short CpsInp055, CpsInp05d;
+extern unsigned short CpsInpPaddle1, CpsInpPaddle2;
 
-extern INT32 PangEEP;
-extern INT32 Forgottn;
-extern INT32 Cps1QsHack;
-extern INT32 Kodh;
-extern INT32 Cawingb;
-extern INT32 Wofh;
-extern INT32 Sf2thndr;
-extern INT32 Pzloop2;
-extern INT32 Ssf2tb;
-extern INT32 Dinohunt;
-extern INT32 Port6SoundWrite;
-extern INT32 CpsBootlegEEPROM;
+extern int PangEEP;
+extern int Forgottn;
+extern int Cps1QsHack;
+extern int Kodh;
+extern int Cawingb;
+extern int Wofh;
+extern int Pzloop2;
+extern int Ssf2tb;
+extern int Dinopic;
+extern int Port6SoundWrite;
 
-extern UINT8* CpsEncZRom;
+extern unsigned char* CpsEncZRom;
 
-INT32 CpsRwInit();
-INT32 CpsRwExit();
-INT32 CpsRwGetInp();
-void CpsWritePort(const UINT32 ia, UINT8 d);
-UINT8 __fastcall CpsReadByte(UINT32 a);
-void __fastcall CpsWriteByte(UINT32 a, UINT8 d);
-UINT16 __fastcall CpsReadWord(UINT32 a);
-void __fastcall CpsWriteWord(UINT32 a, UINT16 d);
-
-typedef void (*CpsRWSoundCommandCallback)(UINT16);
-extern CpsRWSoundCommandCallback CpsRWSoundCommandCallbackFunction;
+int CpsRwInit();
+int CpsRwExit();
+int CpsRwGetInp();
+unsigned char __fastcall CpsReadByte(unsigned int a);
+void __fastcall CpsWriteByte(unsigned int a, unsigned char d);
+unsigned short __fastcall CpsReadWord(unsigned int a);
+void __fastcall CpsWriteWord(unsigned int a, unsigned short d);
 
 // cps_draw.cpp
-extern UINT8 CpsRecalcPal;				// Flag - If it is 1, recalc the whole palette
-extern INT32 nCpsLcReg;							// Address of layer controller register
-extern INT32 CpsLayEn[6];							// bits for layer enable
-extern INT32 nStartline, nEndline;				// specify the vertical slice of the screen to render
-extern INT32 nRasterline[MAX_RASTER + 2];			// The lines at which an interrupt occurs
-extern INT32 MaskAddr[4];
-extern INT32 CpsLayer1XOffs;
-extern INT32 CpsLayer2XOffs;
-extern INT32 CpsLayer3XOffs;
-extern INT32 CpsLayer1YOffs;
-extern INT32 CpsLayer2YOffs;
-extern INT32 CpsLayer3YOffs;
-extern INT32 Cps1DisableBgHi;
-extern INT32 CpsDisableRowScroll;
-extern INT32 Cps1OverrideLayers;
-extern INT32 nCps1Layers[4];
-extern INT32 nCps1LayerOffs[3];
+extern unsigned char CpsRecalcPal;				// Flag - If it is 1, recalc the whole palette
+extern int nCpsLcReg;							// Address of layer controller register
+extern int CpsLayEn[6];							// bits for layer enable
+extern int nStartline, nEndline;				// specify the vertical slice of the screen to render
+extern int nRasterline[MAX_RASTER + 2];			// The lines at which an interrupt occurs
+extern int MaskAddr[4];
+extern int CpsLayer1XOffs;
+extern int CpsLayer2XOffs;
+extern int CpsLayer3XOffs;
+extern int CpsLayer1YOffs;
+extern int CpsLayer2YOffs;
+extern int CpsLayer3YOffs;
 void DrawFnInit();
-INT32  CpsDraw();
-INT32  CpsRedraw();
+int  CpsDraw();
+int  CpsRedraw();
 
-#define BURN_SND_QSND_OUTPUT_1			0
-#define BURN_SND_QSND_OUTPUT_2			1
-
-INT32 QsndInit();
+int QsndInit();
 void QsndSetRoute(INT32 nIndex, double nVolume, INT32 nRouteDir);
 void QsndExit();
 void QsndReset();
 void QsndNewFrame();
 void QsndEndFrame();
 void QsndSyncZ80();
-INT32 QsndScan(INT32 nAction);
+int QsndScan(int nAction);
 
 // qs_z.cpp
-INT32 QsndZInit();
-INT32 QsndZExit();
-INT32 QsndZScan(INT32 nAction);
+int QsndZInit();
+int QsndZExit();
+int QsndZScan(int nAction);
 
 // qs_c.cpp
-INT32 QscInit(INT32 nRate);
+int QscInit(int nRate);
 void QscSetRoute(INT32 nIndex, double nVolume, INT32 nRouteDir);
 void QscReset();
 void QscExit();
-INT32 QscScan(INT32 nAction);
+int QscScan(int nAction);
 void QscNewFrame();
-void QscWrite(INT32 a, INT32 d);
-INT32 QscUpdate(INT32 nEnd);
+void QscWrite(int a, int d);
+int QscUpdate(int nEnd);
 
 // cps_tile.cpp
-extern UINT32* CpstPal;
-extern UINT32 nCpstType; extern INT32 nCpstX,nCpstY;
-extern UINT32 nCpstTile; extern INT32 nCpstFlip;
-extern UINT32 nCpsBlend;
+extern unsigned int* CpstPal;
+extern unsigned int nCpstType; extern int nCpstX,nCpstY;
+extern unsigned int nCpstTile; extern int nCpstFlip;
 extern short* CpstRowShift;
-extern UINT32 CpstPmsk; // Pixel mask
+extern unsigned int CpstPmsk; // Pixel mask
 
-inline static void CpstSetPal(INT32 nPal)
+// Sound outputs
+#define BURN_SND_QSND_OUTPUT_1			0
+#define BURN_SND_QSND_OUTPUT_2			1
+
+// Sound clipping macro
+#define BURN_SND_CLIP(A) ((A) < -0x8000 ? -0x8000 : (A) > 0x7fff ? 0x7fff : (A))
+
+// Sound routes
+#define BURN_SND_ROUTE_LEFT			1
+#define BURN_SND_ROUTE_RIGHT		2
+#define BURN_SND_ROUTE_BOTH			(BURN_SND_ROUTE_LEFT | BURN_SND_ROUTE_RIGHT)
+
+// Macro to determine the size of a struct up to and including "member"
+#define STRUCT_SIZE_HELPER(type, member) offsetof(type, member) + sizeof(((type*)0)->member)
+
+inline static void CpstSetPal(int nPal)
 {
 	nPal <<= 4;
 	nPal &= 0x7F0;
@@ -334,22 +276,22 @@ inline static void CpstSetPal(INT32 nPal)
 }
 
 // ctv.cpp
-extern INT32 nBgHi;
-extern UINT16  ZValue;
-extern UINT16 *ZBuf;
-extern UINT16 *pZVal;
-extern UINT32    nCtvRollX,nCtvRollY;
-extern UINT8  *pCtvTile;					// Pointer to tile data
-extern INT32             nCtvTileAdd;					// Amount to add after each tile line
-extern UINT8  *pCtvLine;					// Pointer to output bitmap
-typedef INT32 (*CtvDoFn)();
-typedef INT32 (*CpstOneDoFn)();
+extern int nBgHi;
+extern unsigned short  ZValue;
+extern unsigned short *ZBuf;
+extern unsigned short *pZVal;
+extern unsigned int    nCtvRollX,nCtvRollY;
+extern unsigned char  *pCtvTile;					// Pointer to tile data
+extern int             nCtvTileAdd;					// Amount to add after each tile line
+extern unsigned char  *pCtvLine;					// Pointer to output bitmap
+typedef int (*CtvDoFn)();
+typedef int (*CpstOneDoFn)();
 extern CtvDoFn CtvDoX[0x20];
 extern CtvDoFn CtvDoXM[0x20];
 extern CtvDoFn CtvDoXB[0x20];
 extern CpstOneDoFn CpstOneDoX[3];
 extern CpstOneDoFn CpstOneObjDoX[2];
-INT32 CtvReady();
+int CtvReady();
 
 // nCpstType constants
 // To get size do (nCpstType & 24) + 8
@@ -361,92 +303,80 @@ INT32 CtvReady();
 #define CTT_32X32 (24)
 
 // cps_obj.cpp
-extern INT32 nCpsObjectBank;
-extern UINT8 *CpsBootlegSpriteRam;
-extern INT32 Cps1LockSpriteList910000;
-extern INT32 Cps1DetectEndSpriteList8000;
+extern int nCpsObjectBank;
 
-typedef INT32 (*Cps1ObjGetCallback)();
-extern Cps1ObjGetCallback Cps1ObjGetCallbackFunction;
-typedef INT32 (*Cps1ObjDrawCallback)(INT32, INT32);
-extern Cps1ObjDrawCallback Cps1ObjDrawCallbackFunction;
+extern unsigned char *BootlegSpriteRam;
 
-INT32  CpsObjInit();
-INT32  CpsObjExit();
-INT32  CpsObjGet();
-INT32 FcrashObjGet();
-INT32 KodbObjGet();
-INT32 DinopicObjGet();
-INT32 DaimakaibObjGet();
-INT32 WofhObjGet();
-INT32 Sf2mdtObjGet();
+extern int Sf2Hack;
+
+int  CpsObjInit();
+int  CpsObjExit();
+int  CpsObjGet();
 void CpsObjDrawInit();
-INT32  Cps1ObjDraw(INT32 nLevelFrom,INT32 nLevelTo);
-INT32  Cps2ObjDraw(INT32 nLevelFrom,INT32 nLevelTo);
-INT32  FcrashObjDraw(INT32 nLevelFrom,INT32 nLevelTo);
+int  Cps1ObjDraw(int nLevelFrom,int nLevelTo);
+int  Cps2ObjDraw(int nLevelFrom,int nLevelTo);
 
 // cps_scr.cpp
 #define SCROLL_2 0
 #define SCROLL_3 1
-extern INT32 Ghouls;
-extern INT32 Ssf2t;
-extern INT32 Xmcota;
-
-extern INT32 Scroll1TileMask;
-extern INT32 Scroll2TileMask;
-extern INT32 Scroll3TileMask;
-INT32 Cps1Scr1Draw(UINT8 *Base,INT32 sx,INT32 sy);
-INT32 Cps1Scr3Draw(UINT8 *Base,INT32 sx,INT32 sy);
-INT32 Cps2Scr1Draw(UINT8 *Base,INT32 sx,INT32 sy);
-INT32 Cps2Scr3Draw(UINT8 *Base,INT32 sx,INT32 sy);
+extern int Ghouls;
+extern int Mercs;
+extern int Sf2jc;
+extern int Ssf2t;
+extern int Qad;
+extern int Xmcota;
+int Cps1Scr1Draw(unsigned char *Base,int sx,int sy);
+int Cps1Scr3Draw(unsigned char *Base,int sx,int sy);
+int Cps2Scr1Draw(unsigned char *Base,int sx,int sy);
+int Cps2Scr3Draw(unsigned char *Base,int sx,int sy);
 
 // cpsr.cpp
-extern UINT8 *CpsrBase;						// Tile data base
-extern INT32 nCpsrScrX,nCpsrScrY;						// Basic scroll info
-extern UINT16 *CpsrRows;					// Row scroll table, 0x400 words long
-extern INT32 nCpsrRowStart;							// Start of row scroll (can wrap?)
+extern unsigned char *CpsrBase;						// Tile data base
+extern int nCpsrScrX,nCpsrScrY;						// Basic scroll info
+extern unsigned short *CpsrRows;					// Row scroll table, 0x400 words long
+extern int nCpsrRowStart;							// Start of row scroll (can wrap?)
 
 // Information needed to draw a line
 struct CpsrLineInfo {
-	INT32 nStart;										// 0-0x3ff - where to start drawing tiles from
-	INT32 nWidth;										// 0-0x400 - width of scroll shifts
+	int nStart;										// 0-0x3ff - where to start drawing tiles from
+	int nWidth;										// 0-0x400 - width of scroll shifts
 													// e.g. for no rowscroll at all, nWidth=0
-	INT32 nTileStart;									// Range of tiles which are visible onscreen
-	INT32 nTileEnd;									// (e.g. 0x20 -> 0x50 , wraps around to 0x10)
-	INT16 Rows[16];									// 16 row scroll values for this line
-	INT32 nMaxLeft, nMaxRight;						// Maximum row shifts left and right
+	int nTileStart;									// Range of tiles which are visible onscreen
+	int nTileEnd;									// (e.g. 0x20 -> 0x50 , wraps around to 0x10)
+	short Rows[16];									// 16 row scroll values for this line
+	int nMaxLeft, nMaxRight;						// Maximum row shifts left and right
 };
 extern struct CpsrLineInfo CpsrLineInfo[15];
-INT32 Cps1rPrepare();
-INT32 Cps2rPrepare();
+int Cps1rPrepare();
+int Cps2rPrepare();
 
 // cpsrd.cpp
-INT32 Cps1rRender();
-INT32 Cps2rRender();
+int Cps1rRender();
+int Cps2rRender();
 
 // dc_input.cpp
 extern struct BurnInputInfo CpsFsi[0x1B];
 
 // ps.cpp
-extern UINT8 PsndCode, PsndFade;			// Sound code/fade sent to the z80 program
-INT32 PsndInit();
-INT32 PsndExit();
+extern unsigned char PsndCode, PsndFade;			// Sound code/fade sent to the z80 program
+int PsndInit();
+int PsndExit();
 void PsndNewFrame();
-INT32 PsndSyncZ80(INT32 nCycles);
-INT32 PsndScan(INT32 nAction);
+int PsndSyncZ80(int nCycles);
+int PsndScan(int nAction);
 
 // ps_z.cpp
-INT32 PsndZInit();
-INT32 PsndZExit();
-INT32 PsndZScan(INT32 nAction);
-extern INT32 Kodb;
+int PsndZInit();
+int PsndZExit();
+int PsndZScan(int nAction);
+extern int Kodb;
 
 // ps_m.cpp
-extern INT32 bPsmOkay;								// 1 if the module is okay
-INT32 PsmInit();
-INT32 PsmExit();
+extern int bPsmOkay;								// 1 if the module is okay
+int PsmInit();
+int PsmExit();
 void PsmNewFrame();
-INT32 PsmUpdate(INT32 nEnd);
+int PsmUpdate(int nEnd);
 
 // kabuki.cpp
 void wof_decode();
@@ -456,41 +386,3 @@ void slammast_decode();
 
 // cps2_crypt.cpp
 void cps2_decrypt_game_data();
-
-// fcrash_snd.cpp
-void FcrashSoundCommand(UINT16 d);
-INT32 FcrashSoundInit();
-INT32 FcrashSoundReset();
-INT32 FcrashSoundExit();
-void FcrashSoundFrameStart();
-void FcrashSoundFrameEnd();
-INT32 FcrashScanSound(INT32 nAction, INT32 *pnMin);
-
-// sf2mdt_snd.cpp
-void Sf2mdtSoundCommand(UINT16 d);
-INT32 Sf2mdtSoundInit();
-INT32 Sf2mdtSoundReset();
-INT32 Sf2mdtSoundExit();
-void Sf2mdtSoundFrameStart();
-void Sf2mdtSoundFrameEnd();
-INT32 Sf2mdtScanSound(INT32 nAction, INT32 *pnMin);
-
-// d_cps2.cpp
-#define CPS2_PRG_68K						1
-#define CPS2_PRG_68K_SIMM					2
-#define CPS2_PRG_68K_XOR_TABLE				3
-#define CPS2_GFX							5
-#define CPS2_GFX_SIMM						6
-#define CPS2_GFX_SPLIT4						7
-#define CPS2_GFX_SPLIT8						8
-#define CPS2_GFX_19XXJ						9
-#define CPS2_PRG_Z80						10
-#define CPS2_QSND							12
-#define CPS2_QSND_SIMM						13
-#define CPS2_QSND_SIMM_BYTESWAP				14
-
-extern INT32 Cps2Volume;
-extern UINT16 Cps2VolumeStates[40];
-extern INT32 Cps2DisableDigitalVolume;
-extern UINT8 Cps2VolUp;
-extern UINT8 Cps2VolDwn;

--- a/src/burn/capcom/cps.h
+++ b/src/burn/capcom/cps.h
@@ -25,9 +25,8 @@ extern UINT8 *CpsGfx;  extern UINT32 nCpsGfxLen;		// All the graphics
 extern UINT8 *CpsRom;  extern UINT32 nCpsRomLen;		// Program Rom (as in rom)
 extern UINT8 *CpsCode; extern UINT32 nCpsCodeLen;		// Program Rom (decrypted)
 extern UINT8 *CpsZRom; extern UINT32 nCpsZRomLen;		// Z80 Roms
-extern  INT8 *CpsQSam; extern UINT32 nCpsQSamLen;		// QSound Sample Roms
-extern UINT8 *CpsAd;   extern UINT32 nCpsAdLen;		    // ADPCM Data
-extern UINT8 *CpsKey; extern UINT32 nCpsKeyLen;
+extern          INT8 *CpsQSam; extern UINT32 nCpsQSamLen;		// QSound Sample Roms
+extern UINT8 *CpsAd;   extern UINT32 nCpsAdLen;		// ADPCM Data
 extern UINT32 nCpsGfxScroll[4];								// Offset to Scroll tiles
 extern UINT32 nCpsGfxMask;									// Address mask
 extern UINT8* CpsStar;
@@ -37,7 +36,6 @@ INT32 CpsExit();
 INT32 CpsLoadTiles(UINT8 *Tile,INT32 nStart);
 INT32 CpsLoadTilesByte(UINT8 *Tile,INT32 nStart);
 INT32 CpsLoadTilesForgottn(INT32 nStart);
-INT32 CpsLoadTilesForgottna(INT32 nStart);
 INT32 CpsLoadTilesForgottnu(INT32 nStart);
 INT32 CpsLoadTilesPang(UINT8 *Tile,INT32 nStart);
 INT32 CpsLoadTilesSf2ebbl(UINT8 *Tile, INT32 nStart);
@@ -62,10 +60,6 @@ INT32 CpsLoadTilesSlampic(INT32 nStart);
 INT32 CpsLoadTilesKodb(INT32 nStart);
 INT32 CpsLoadTilesWonder3b(INT32 nStart);
 INT32 CpsLoadTilesPang3r1a(INT32 nStart);
-INT32 CpsLoadTilesPunisherb(INT32 nStart);
-INT32 CpsLoadTilesKnightsb2(INT32 nStart);
-INT32 CpsLoadTilesMtwinsb(INT32 nStart);
-INT32 CpsLoadTilesWofabl(INT32 nStart);
 INT32 CpsLoadStars(UINT8 *pStar, INT32 nStart);
 INT32 CpsLoadStarsByte(UINT8 *pStar, INT32 nStart);
 INT32 CpsLoadStarsForgottnAlt(UINT8 *pStar, INT32 nStart);
@@ -153,10 +147,8 @@ INT32 Cps2LoadTilesGigaman2(UINT8 *Tile, UINT8 *pSrc);
 #define mapper_PKB10B		37
 #define mapper_pang3		38
 #define mapper_sfzch		39
-#define mapper_cps2			40
-#define mapper_frog			41
-#define mapper_pokon		42
-#define mapper_KNM10B		43
+#define mapper_cps2		40
+#define mapper_frog		41
 extern void SetGfxMapper(INT32 MapperId);
 extern INT32 GfxRomBankMapper(INT32 Type, INT32 Code);
 extern void SetCpsBId(INT32 CpsBId, INT32 bStars);
@@ -187,9 +179,7 @@ extern CpsMemScanCallback CpsMemScanCallbackFunction;
 
 // cps_run.cpp
 extern UINT8 CpsReset;
-extern INT32 nCpsCyclesExtra;
 extern UINT8 Cpi01A, Cpi01C, Cpi01E;
-extern UINT8 fFakeDip;
 extern INT32 nIrqLine50, nIrqLine52;								// The scanlines at which the interrupts are triggered
 extern INT32 nCpsNumScanlines;
 extern INT32 Cps1VBlankIRQLine;
@@ -251,7 +241,6 @@ CPSINPEX
 // For the Forgotten Worlds analog controls
 extern UINT16 CpsInp055, CpsInp05d;
 extern UINT16 CpsInpPaddle1, CpsInpPaddle2;
-extern UINT8 CpsDigUD[4];
 
 extern INT32 PangEEP;
 extern INT32 Forgottn;
@@ -261,8 +250,6 @@ extern INT32 Cawingb;
 extern INT32 Wofh;
 extern INT32 Sf2thndr;
 extern INT32 Pzloop2;
-extern INT32 Mmatrix;
-extern INT32 Sfa2ObjHack;
 extern INT32 Ssf2tb;
 extern INT32 Dinohunt;
 extern INT32 Port6SoundWrite;
@@ -446,12 +433,12 @@ INT32 PsndInit();
 INT32 PsndExit();
 void PsndNewFrame();
 INT32 PsndSyncZ80(INT32 nCycles);
-INT32 PsndScan(INT32 nAction, INT32 *pnMin);
+INT32 PsndScan(INT32 nAction);
 
 // ps_z.cpp
 INT32 PsndZInit();
 INT32 PsndZExit();
-INT32 PsndZScan(INT32 nAction, INT32 *pnMin);
+INT32 PsndZScan(INT32 nAction);
 extern INT32 Kodb;
 
 // ps_m.cpp
@@ -501,7 +488,6 @@ INT32 Sf2mdtScanSound(INT32 nAction, INT32 *pnMin);
 #define CPS2_QSND							12
 #define CPS2_QSND_SIMM						13
 #define CPS2_QSND_SIMM_BYTESWAP				14
-#define CPS2_ENCRYPTION_KEY					15
 
 extern INT32 Cps2Volume;
 extern UINT16 Cps2VolumeStates[40];

--- a/src/burn/capcom/cps.h
+++ b/src/burn/capcom/cps.h
@@ -237,7 +237,7 @@ int QsndZExit();
 int QsndZScan(int nAction);
 
 // qs_c.cpp
-int QscInit(int nRate);
+int QscInit(int nRate, int nVolumeShift);
 void QscSetRoute(INT32 nIndex, double nVolume, INT32 nRouteDir);
 void QscReset();
 void QscExit();

--- a/src/burn/capcom/cps.h
+++ b/src/burn/capcom/cps.h
@@ -1,46 +1,77 @@
 // CPS ----------------------------------
 #include "burnint.h"
+#include "m68000_intf.h"
+#include "z80_intf.h"
 
 #include "msm6295.h"
-#include "eeprom_93cxx.h"
+#include "eeprom.h"
 #include "timer.h"
 
 // Maximum number of beam-synchronized interrupts to check
 #define MAX_RASTER 10
 
-extern unsigned int CpsMProt[4];									// Mprot changes
-extern unsigned int CpsBID[3];										// Board ID changes
+extern UINT32 CpsMProt[4];									// Mprot changes
+extern UINT32 CpsBID[3];										// Board ID changes
 
 // cps.cpp
-extern int Cps;														// 1 = CPS1, 2 = CPS2, 3 = CPS CHanger
-extern int Cps1Qs;
-extern int Cps1Pic;
-extern int nCPS68KClockspeed;
-extern int nCpsCycles;												// Cycles per frame
-extern int nCpsZ80Cycles;
-extern unsigned char *CpsGfx;  extern unsigned int nCpsGfxLen;		// All the graphics
-extern unsigned char *CpsRom;  extern unsigned int nCpsRomLen;		// Program Rom (as in rom)
-extern unsigned char *CpsCode; extern unsigned int nCpsCodeLen;		// Program Rom (decrypted)
-extern unsigned char *CpsZRom; extern unsigned int nCpsZRomLen;		// Z80 Roms
-extern          char *CpsQSam; extern unsigned int nCpsQSamLen;		// QSound Sample Roms
-extern unsigned char *CpsAd;   extern unsigned int nCpsAdLen;		// ADPCM Data
-extern unsigned int nCpsGfxScroll[4];								// Offset to Scroll tiles
-extern unsigned int nCpsGfxMask;									// Address mask
-extern unsigned char* CpsStar;
-int CpsInit();
-int Cps2Init();
-int CpsExit();
-int CpsLoadTiles(unsigned char *Tile,int nStart);
-int CpsLoadTilesByte(unsigned char *Tile,int nStart);
-int CpsLoadTilesPang(unsigned char *Tile,int nStart);
-int CpsLoadTilesHack160(unsigned char *Tile,int nStart);
-int CpsLoadTilesBootleg(unsigned char *Tile, int nStart);
-int CpsLoadTilesCaptcomb(unsigned char *Tile, int nStart);
-int CpsLoadTilesPunipic2(unsigned char *Tile, int nStart);
-int CpsLoadStars(unsigned char *pStar, int nStart);
-int CpsLoadStarsByte(unsigned char *pStar, int nStart);
-int Cps2LoadTiles(unsigned char *Tile,int nStart);
-int Cps2LoadTilesSIM(unsigned char *Tile,int nStart);
+extern INT32 Cps;														// 1 = CPS1, 2 = CPS2, 3 = CPS CHanger
+extern INT32 Cps1Qs;
+extern INT32 Cps1DisablePSnd;
+extern INT32 Cps2DisableQSnd;
+extern INT32 nCPS68KClockspeed;
+extern INT32 nCpsCycles;												// Cycles per frame
+extern INT32 nCpsZ80Cycles;
+extern UINT8 *CpsGfx;  extern UINT32 nCpsGfxLen;		// All the graphics
+extern UINT8 *CpsRom;  extern UINT32 nCpsRomLen;		// Program Rom (as in rom)
+extern UINT8 *CpsCode; extern UINT32 nCpsCodeLen;		// Program Rom (decrypted)
+extern UINT8 *CpsZRom; extern UINT32 nCpsZRomLen;		// Z80 Roms
+extern  INT8 *CpsQSam; extern UINT32 nCpsQSamLen;		// QSound Sample Roms
+extern UINT8 *CpsAd;   extern UINT32 nCpsAdLen;		    // ADPCM Data
+extern UINT8 *CpsKey; extern UINT32 nCpsKeyLen;
+extern UINT32 nCpsGfxScroll[4];								// Offset to Scroll tiles
+extern UINT32 nCpsGfxMask;									// Address mask
+extern UINT8* CpsStar;
+INT32 CpsInit();
+INT32 Cps2Init();
+INT32 CpsExit();
+INT32 CpsLoadTiles(UINT8 *Tile,INT32 nStart);
+INT32 CpsLoadTilesByte(UINT8 *Tile,INT32 nStart);
+INT32 CpsLoadTilesForgottn(INT32 nStart);
+INT32 CpsLoadTilesForgottna(INT32 nStart);
+INT32 CpsLoadTilesForgottnu(INT32 nStart);
+INT32 CpsLoadTilesPang(UINT8 *Tile,INT32 nStart);
+INT32 CpsLoadTilesSf2ebbl(UINT8 *Tile, INT32 nStart);
+INT32 CpsLoadTilesSf2b(UINT8 *Tile, INT32 nStart);
+INT32 CpsLoadTilesSf2koryuExtra(UINT8 *Tile, INT32 nStart);
+INT32 CpsLoadTilesHack160(INT32 nStart);
+INT32 CpsLoadTilesHack160Alt(INT32 nStart);
+INT32 CpsLoadTilesSf2koryu(INT32 nStart);
+INT32 CpsLoadTilesSf2stt(INT32 nStart);
+INT32 CpsLoadTilesSf2mdt(INT32 nStart);
+INT32 CpsLoadTilesSf2mdta(INT32 nStart);
+INT32 CpsLoadTilesSf2ceuab3(INT32 nStart);
+INT32 CpsLoadTilesSf2ceeabl(INT32 nStart);
+INT32 CpsLoadTilesSf2ceuab7(INT32 nStart);
+INT32 CpsLoadTilesSf2ebbl3(INT32 nStart);
+INT32 CpsLoadTilesFcrash(INT32 nStart);
+INT32 CpsLoadTilesCawingbl(INT32 nStart);
+INT32 CpsLoadTilesCaptcommb(INT32 nStart);
+INT32 CpsLoadTilesDinopic(INT32 nStart);
+INT32 CpsLoadTilesDinopic4(INT32 nStart);
+INT32 CpsLoadTilesSlampic(INT32 nStart);
+INT32 CpsLoadTilesKodb(INT32 nStart);
+INT32 CpsLoadTilesWonder3b(INT32 nStart);
+INT32 CpsLoadTilesPang3r1a(INT32 nStart);
+INT32 CpsLoadTilesPunisherb(INT32 nStart);
+INT32 CpsLoadTilesKnightsb2(INT32 nStart);
+INT32 CpsLoadTilesMtwinsb(INT32 nStart);
+INT32 CpsLoadTilesWofabl(INT32 nStart);
+INT32 CpsLoadStars(UINT8 *pStar, INT32 nStart);
+INT32 CpsLoadStarsByte(UINT8 *pStar, INT32 nStart);
+INT32 CpsLoadStarsForgottnAlt(UINT8 *pStar, INT32 nStart);
+INT32 Cps2LoadTiles(UINT8 *Tile,INT32 nStart);
+INT32 Cps2LoadTilesSIM(UINT8 *Tile,INT32 nStart);
+INT32 Cps2LoadTilesGigaman2(UINT8 *Tile, UINT8 *pSrc);
 
 // cps_config.h
 #define CPS_B_01		0
@@ -72,6 +103,9 @@ int Cps2LoadTilesSIM(unsigned char *Tile,int nStart);
 #define HACK_B_1		26
 #define HACK_B_2		27
 #define HACK_B_3		28
+#define HACK_B_4		29
+#define HACK_B_5		30
+#define HACK_B_6		31
 
 #define GFXTYPE_SPRITES		(1<<0)
 #define GFXTYPE_SCROLL1		(1<<1)
@@ -80,178 +114,232 @@ int Cps2LoadTilesSIM(unsigned char *Tile,int nStart);
 #define GFXTYPE_STARS		(1<<4)
 
 #define mapper_LWCHR		0
-#define mapper_DM620		1
-#define mapper_ST24M1		2
-#define mapper_DM22A		3
-#define mapper_ST22B		4
-#define mapper_TK22B		5
-#define mapper_WL24B		6
-#define mapper_S224B		7
-#define mapper_YI24B		8
-#define mapper_AR24B		9
-#define mapper_AR22B		10
-#define mapper_O224B		11
-#define mapper_MS24B		12
-#define mapper_CK24B		13
-#define mapper_NM24B		14
-#define mapper_CA24B		15
-#define mapper_CA22B		16
-#define mapper_STF29		17
-#define mapper_RT24B		18
-#define mapper_RT22B		19
-#define mapper_KD29B		20
-#define mapper_CC63B		21
-#define mapper_KR63B		22
-#define mapper_S9263B		23
-#define mapper_VA63B		24
-#define mapper_Q522B		25
-#define mapper_TK263B		26
-#define mapper_CD63B		27
-#define mapper_PS63B		28
-#define mapper_MB63B		29
-#define mapper_QD22B		30
-#define mapper_qadj		31
-#define mapper_qtono2		32
-#define mapper_RCM63B		33
-#define mapper_pnickj		34
-#define mapper_pang3		35
-#define mapper_sfzch		36
-#define mapper_cps2		37
-#define mapper_frog		38
-extern void SetGfxMapper(int MapperId);
-extern int GfxRomBankMapper(int Type, int Code);
-extern void SetCpsBId(int CpsBId, int bStars);
+#define mapper_LW621		1
+#define mapper_DM620		2
+#define mapper_ST24M1		3
+#define mapper_DM22A		4
+#define mapper_DAM63B		5
+#define mapper_ST22B		6
+#define mapper_TK22B		7
+#define mapper_WL24B		8
+#define mapper_S224B		9
+#define mapper_YI24B		10
+#define mapper_AR24B		11
+#define mapper_AR22B		12
+#define mapper_O224B		13
+#define mapper_MS24B		14
+#define mapper_CK24B		15
+#define mapper_NM24B		16
+#define mapper_CA24B		17
+#define mapper_CA22B		18
+#define mapper_STF29		19
+#define mapper_RT24B		20
+#define mapper_RT22B		21
+#define mapper_KD29B		22
+#define mapper_CC63B		23
+#define mapper_KR63B		24
+#define mapper_S9263B		25
+#define mapper_VA63B		26
+#define mapper_VA22B		27
+#define mapper_Q522B		28
+#define mapper_TK263B		29
+#define mapper_CD63B		30
+#define mapper_PS63B		31
+#define mapper_MB63B		32
+#define mapper_QD22B		33
+#define mapper_QD63B		34
+#define mapper_TN2292		35
+#define mapper_RCM63B		36
+#define mapper_PKB10B		37
+#define mapper_pang3		38
+#define mapper_sfzch		39
+#define mapper_cps2			40
+#define mapper_frog			41
+#define mapper_pokon		42
+#define mapper_KNM10B		43
+extern void SetGfxMapper(INT32 MapperId);
+extern INT32 GfxRomBankMapper(INT32 Type, INT32 Code);
+extern void SetCpsBId(INT32 CpsBId, INT32 bStars);
 
 // cps_pal.cpp
-extern unsigned int* CpsPal;										// Hicolor version of palette
-extern unsigned int* CpsObjPal;										// Pointer to lagged obj palette
-extern int nLagObjectPalettes;										// Lag object palettes by one frame if non-zero
-int CpsPalInit();
-int CpsPalExit();
-int CpsPalUpdate(unsigned char *pNewPal,int bRecalcAll);
-int CpsStarPalUpdate(unsigned char* pNewPal, int nLayer, int bRecalcAll);
+extern UINT32* CpsPal;										// Hicolor version of palette
+extern INT32 nCpsPalCtrlReg;
+extern INT32 bCpsUpdatePalEveryFrame;
+INT32 CpsPalInit();
+INT32 CpsPalExit();
+INT32 CpsPalUpdate(UINT8 *pNewPal);
 
 // cps_mem.cpp
-extern unsigned char *CpsRam90;
-extern unsigned char *CpsZRamC0,*CpsZRamF0;
-extern unsigned char *CpsSavePal;
-extern unsigned char *CpsRam708,*CpsReg,*CpsFrg;
-extern unsigned char *CpsSaveReg[MAX_RASTER + 1];
-extern unsigned char *CpsSaveFrg[MAX_RASTER + 1];
-extern unsigned char *CpsRamFF;
-void CpsMapObjectBanks(int nBank);
-int CpsMemInit();
-int CpsMemExit();
-int CpsAreaScan(int nAction,int *pnMin);
+extern UINT8 *CpsRam90;
+extern UINT8 *CpsZRamC0,*CpsZRamF0;
+extern UINT8 *CpsSavePal;
+extern UINT8 *CpsRam708,*CpsReg,*CpsFrg;
+extern UINT8 *CpsSaveReg[MAX_RASTER + 1];
+extern UINT8 *CpsSaveFrg[MAX_RASTER + 1];
+extern UINT8 *CpsRamFF;
+void CpsMapObjectBanks(INT32 nBank);
+INT32 CpsMemInit();
+INT32 CpsMemExit();
+INT32 CpsAreaScan(INT32 nAction,INT32 *pnMin);
+
+typedef INT32 (*CpsMemScanCallback)(INT32, INT32*);
+extern CpsMemScanCallback CpsMemScanCallbackFunction;
 
 // cps_run.cpp
-extern unsigned char CpsReset;
-extern unsigned char Cpi01A, Cpi01C, Cpi01E;
-extern int nIrqLine50, nIrqLine52;								// The scanlines at which the interrupts are triggered
-extern int CpsDrawSpritesInReverse;
-int CpsRunInit();
-int CpsRunExit();
-int Cps1Frame();
-int Cps2Frame();
+extern UINT8 CpsReset;
+extern INT32 nCpsCyclesExtra;
+extern UINT8 Cpi01A, Cpi01C, Cpi01E;
+extern UINT8 fFakeDip;
+extern INT32 nIrqLine50, nIrqLine52;								// The scanlines at which the interrupts are triggered
+extern INT32 nCpsNumScanlines;
+extern INT32 Cps1VBlankIRQLine;
+extern INT32 CpsDrawSpritesInReverse;
+INT32 CpsRunInit();
+INT32 CpsRunExit();
+INT32 Cps1Frame();
+INT32 Cps2Frame();
+typedef INT32 (*CpsRunInitCallback)();
+extern CpsRunInitCallback CpsRunInitCallbackFunction;
+typedef INT32 (*CpsRunExitCallback)();
+extern CpsRunExitCallback CpsRunExitCallbackFunction;
+typedef INT32 (*CpsRunResetCallback)();
+extern CpsRunResetCallback CpsRunResetCallbackFunction;
+typedef void (*CpsRunFrameStartCallback)();
+extern CpsRunFrameStartCallback CpsRunFrameStartCallbackFunction;
+typedef void (*CpsRunFrameMiddleCallback)();
+extern CpsRunFrameMiddleCallback CpsRunFrameMiddleCallbackFunction;
+typedef void (*CpsRunFrameEndCallback)();
+extern CpsRunFrameEndCallback CpsRunFrameEndCallbackFunction;
 
-inline static unsigned char* CpsFindGfxRam(int nAddr,int nLen)
+inline static UINT8* CpsFindGfxRam(INT32 nAddr,INT32 nLen)
 {
   nAddr&=0xffffff; // 24-bit bus
   if (nAddr>=0x900000 && nAddr+nLen<=0x930000) return CpsRam90+nAddr-0x900000;
   return NULL;
 }
 
+inline static void GetPalette(INT32 nStart, INT32 nCount)
+{
+	// Update Palette (Ghouls points to the wrong place on boot up I think)
+	INT32 nPal = (BURN_ENDIAN_SWAP_INT16(*((UINT16*)(CpsReg + 0x0A))) << 8) & 0xFFFC00;
+	
+	UINT8* Find = CpsFindGfxRam(nPal, 0xc00 << 1);
+	if (Find) {
+		memcpy(CpsSavePal + (nStart << 10), Find + (nStart << 10), nCount << 10);
+	}
+}
+
 // cps_rw.cpp
 // Treble Winner - Added INP(1FD) for sf2ue
-#define CPSINPSET INP(000) INP(001) INP(006) INP(007) INP(008) INP(010) INP(011) INP(012) INP(018) INP(019) INP(020) INP(021) INP(029) INP(176) INP(177) INP(179) INP(186) INP(1fd)
+#define CPSINPSET INP(000) INP(001) INP(006) INP(007) INP(008) INP(010) INP(011) INP(012) INP(018) INP(019) INP(01B) INP(020) INP(021) INP(029) INP(176) INP(177) INP(179) INP(186) INP(1fd)
 
 // prototype for input bits
-#define INP(nnn) extern unsigned char CpsInp##nnn[8];
+#define INP(nnn) extern UINT8 CpsInp##nnn[8];
 CPSINPSET
 #undef  INP
 
-#define INP(nnn) extern unsigned char Inp##nnn;
+#define INP(nnn) extern UINT8 Inp##nnn;
 CPSINPSET
 #undef  INP
 
 #define CPSINPEX INP(c000) INP(c001) INP(c002) INP(c003)
 
-#define INP(nnnn) extern unsigned char CpsInp##nnnn[8];
+#define INP(nnnn) extern UINT8 CpsInp##nnnn[8];
 CPSINPEX
 #undef  INP
 
 // For the Forgotten Worlds analog controls
-extern unsigned short CpsInp055, CpsInp05d;
-extern unsigned short CpsInpPaddle1, CpsInpPaddle2;
+extern UINT16 CpsInp055, CpsInp05d;
+extern UINT16 CpsInpPaddle1, CpsInpPaddle2;
+extern UINT8 CpsDigUD[4];
 
-extern int PangEEP;
-extern int Forgottn;
-extern int Cps1QsHack;
-extern int Kodh;
-extern int Cawingb;
-extern int Wofh;
-extern int Pzloop2;
-extern int Ssf2tb;
-extern int Dinopic;
-extern int Port6SoundWrite;
+extern INT32 PangEEP;
+extern INT32 Forgottn;
+extern INT32 Cps1QsHack;
+extern INT32 Kodh;
+extern INT32 Cawingb;
+extern INT32 Wofh;
+extern INT32 Sf2thndr;
+extern INT32 Pzloop2;
+extern INT32 Mmatrix;
+extern INT32 Sfa2ObjHack;
+extern INT32 Ssf2tb;
+extern INT32 Dinohunt;
+extern INT32 Port6SoundWrite;
+extern INT32 CpsBootlegEEPROM;
 
-extern unsigned char* CpsEncZRom;
+extern UINT8* CpsEncZRom;
 
-int CpsRwInit();
-int CpsRwExit();
-int CpsRwGetInp();
-unsigned char __fastcall CpsReadByte(unsigned int a);
-void __fastcall CpsWriteByte(unsigned int a, unsigned char d);
-unsigned short __fastcall CpsReadWord(unsigned int a);
-void __fastcall CpsWriteWord(unsigned int a, unsigned short d);
+INT32 CpsRwInit();
+INT32 CpsRwExit();
+INT32 CpsRwGetInp();
+void CpsWritePort(const UINT32 ia, UINT8 d);
+UINT8 __fastcall CpsReadByte(UINT32 a);
+void __fastcall CpsWriteByte(UINT32 a, UINT8 d);
+UINT16 __fastcall CpsReadWord(UINT32 a);
+void __fastcall CpsWriteWord(UINT32 a, UINT16 d);
+
+typedef void (*CpsRWSoundCommandCallback)(UINT16);
+extern CpsRWSoundCommandCallback CpsRWSoundCommandCallbackFunction;
 
 // cps_draw.cpp
-extern unsigned char CpsRecalcPal;				// Flag - If it is 1, recalc the whole palette
-extern int nCpsLcReg;							// Address of layer controller register
-extern int CpsLayEn[6];							// bits for layer enable
-extern int nStartline, nEndline;				// specify the vertical slice of the screen to render
-extern int nRasterline[MAX_RASTER + 2];			// The lines at which an interrupt occurs
-extern int MaskAddr[4];
-extern int CpsLayer1XOffs;
-extern int CpsLayer2XOffs;
-extern int CpsLayer3XOffs;
-extern int CpsLayer1YOffs;
-extern int CpsLayer2YOffs;
-extern int CpsLayer3YOffs;
+extern UINT8 CpsRecalcPal;				// Flag - If it is 1, recalc the whole palette
+extern INT32 nCpsLcReg;							// Address of layer controller register
+extern INT32 CpsLayEn[6];							// bits for layer enable
+extern INT32 nStartline, nEndline;				// specify the vertical slice of the screen to render
+extern INT32 nRasterline[MAX_RASTER + 2];			// The lines at which an interrupt occurs
+extern INT32 MaskAddr[4];
+extern INT32 CpsLayer1XOffs;
+extern INT32 CpsLayer2XOffs;
+extern INT32 CpsLayer3XOffs;
+extern INT32 CpsLayer1YOffs;
+extern INT32 CpsLayer2YOffs;
+extern INT32 CpsLayer3YOffs;
+extern INT32 Cps1DisableBgHi;
+extern INT32 CpsDisableRowScroll;
+extern INT32 Cps1OverrideLayers;
+extern INT32 nCps1Layers[4];
+extern INT32 nCps1LayerOffs[3];
 void DrawFnInit();
-int  CpsDraw();
-int  CpsRedraw();
+INT32  CpsDraw();
+INT32  CpsRedraw();
 
-int QsndInit();
+#define BURN_SND_QSND_OUTPUT_1			0
+#define BURN_SND_QSND_OUTPUT_2			1
+
+INT32 QsndInit();
+void QsndSetRoute(INT32 nIndex, double nVolume, INT32 nRouteDir);
 void QsndExit();
 void QsndReset();
 void QsndNewFrame();
 void QsndEndFrame();
 void QsndSyncZ80();
-int QsndScan(int nAction);
+INT32 QsndScan(INT32 nAction);
 
 // qs_z.cpp
-int QsndZInit();
-int QsndZExit();
-int QsndZScan(int nAction);
+INT32 QsndZInit();
+INT32 QsndZExit();
+INT32 QsndZScan(INT32 nAction);
 
 // qs_c.cpp
-int QscInit(int nRate, int nVolumeShift);
+INT32 QscInit(INT32 nRate);
+void QscSetRoute(INT32 nIndex, double nVolume, INT32 nRouteDir);
 void QscReset();
 void QscExit();
-int QscScan(int nAction);
+INT32 QscScan(INT32 nAction);
 void QscNewFrame();
-void QscWrite(int a, int d);
-int QscUpdate(int nEnd);
+void QscWrite(INT32 a, INT32 d);
+INT32 QscUpdate(INT32 nEnd);
 
 // cps_tile.cpp
-extern unsigned int* CpstPal;
-extern unsigned int nCpstType; extern int nCpstX,nCpstY;
-extern unsigned int nCpstTile; extern int nCpstFlip;
+extern UINT32* CpstPal;
+extern UINT32 nCpstType; extern INT32 nCpstX,nCpstY;
+extern UINT32 nCpstTile; extern INT32 nCpstFlip;
+extern UINT32 nCpsBlend;
 extern short* CpstRowShift;
-extern unsigned int CpstPmsk; // Pixel mask
+extern UINT32 CpstPmsk; // Pixel mask
 
-inline static void CpstSetPal(int nPal)
+inline static void CpstSetPal(INT32 nPal)
 {
 	nPal <<= 4;
 	nPal &= 0x7F0;
@@ -259,22 +347,22 @@ inline static void CpstSetPal(int nPal)
 }
 
 // ctv.cpp
-extern int nBgHi;
-extern unsigned short  ZValue;
-extern unsigned short *ZBuf;
-extern unsigned short *pZVal;
-extern unsigned int    nCtvRollX,nCtvRollY;
-extern unsigned char  *pCtvTile;					// Pointer to tile data
-extern int             nCtvTileAdd;					// Amount to add after each tile line
-extern unsigned char  *pCtvLine;					// Pointer to output bitmap
-typedef int (*CtvDoFn)();
-typedef int (*CpstOneDoFn)();
+extern INT32 nBgHi;
+extern UINT16  ZValue;
+extern UINT16 *ZBuf;
+extern UINT16 *pZVal;
+extern UINT32    nCtvRollX,nCtvRollY;
+extern UINT8  *pCtvTile;					// Pointer to tile data
+extern INT32             nCtvTileAdd;					// Amount to add after each tile line
+extern UINT8  *pCtvLine;					// Pointer to output bitmap
+typedef INT32 (*CtvDoFn)();
+typedef INT32 (*CpstOneDoFn)();
 extern CtvDoFn CtvDoX[0x20];
 extern CtvDoFn CtvDoXM[0x20];
 extern CtvDoFn CtvDoXB[0x20];
 extern CpstOneDoFn CpstOneDoX[3];
 extern CpstOneDoFn CpstOneObjDoX[2];
-int CtvReady();
+INT32 CtvReady();
 
 // nCpstType constants
 // To get size do (nCpstType & 24) + 8
@@ -286,80 +374,92 @@ int CtvReady();
 #define CTT_32X32 (24)
 
 // cps_obj.cpp
-extern int nCpsObjectBank;
+extern INT32 nCpsObjectBank;
+extern UINT8 *CpsBootlegSpriteRam;
+extern INT32 Cps1LockSpriteList910000;
+extern INT32 Cps1DetectEndSpriteList8000;
 
-extern unsigned char *BootlegSpriteRam;
+typedef INT32 (*Cps1ObjGetCallback)();
+extern Cps1ObjGetCallback Cps1ObjGetCallbackFunction;
+typedef INT32 (*Cps1ObjDrawCallback)(INT32, INT32);
+extern Cps1ObjDrawCallback Cps1ObjDrawCallbackFunction;
 
-extern int Sf2Hack;
-
-int  CpsObjInit();
-int  CpsObjExit();
-int  CpsObjGet();
+INT32  CpsObjInit();
+INT32  CpsObjExit();
+INT32  CpsObjGet();
+INT32 FcrashObjGet();
+INT32 KodbObjGet();
+INT32 DinopicObjGet();
+INT32 DaimakaibObjGet();
+INT32 WofhObjGet();
+INT32 Sf2mdtObjGet();
 void CpsObjDrawInit();
-int  Cps1ObjDraw(int nLevelFrom,int nLevelTo);
-int  Cps2ObjDraw(int nLevelFrom,int nLevelTo);
+INT32  Cps1ObjDraw(INT32 nLevelFrom,INT32 nLevelTo);
+INT32  Cps2ObjDraw(INT32 nLevelFrom,INT32 nLevelTo);
+INT32  FcrashObjDraw(INT32 nLevelFrom,INT32 nLevelTo);
 
 // cps_scr.cpp
 #define SCROLL_2 0
 #define SCROLL_3 1
-extern int Ghouls;
-extern int Mercs;
-extern int Sf2jc;
-extern int Ssf2t;
-extern int Qad;
-extern int Xmcota;
-int Cps1Scr1Draw(unsigned char *Base,int sx,int sy);
-int Cps1Scr3Draw(unsigned char *Base,int sx,int sy);
-int Cps2Scr1Draw(unsigned char *Base,int sx,int sy);
-int Cps2Scr3Draw(unsigned char *Base,int sx,int sy);
+extern INT32 Ghouls;
+extern INT32 Ssf2t;
+extern INT32 Xmcota;
+
+extern INT32 Scroll1TileMask;
+extern INT32 Scroll2TileMask;
+extern INT32 Scroll3TileMask;
+INT32 Cps1Scr1Draw(UINT8 *Base,INT32 sx,INT32 sy);
+INT32 Cps1Scr3Draw(UINT8 *Base,INT32 sx,INT32 sy);
+INT32 Cps2Scr1Draw(UINT8 *Base,INT32 sx,INT32 sy);
+INT32 Cps2Scr3Draw(UINT8 *Base,INT32 sx,INT32 sy);
 
 // cpsr.cpp
-extern unsigned char *CpsrBase;						// Tile data base
-extern int nCpsrScrX,nCpsrScrY;						// Basic scroll info
-extern unsigned short *CpsrRows;					// Row scroll table, 0x400 words long
-extern int nCpsrRowStart;							// Start of row scroll (can wrap?)
+extern UINT8 *CpsrBase;						// Tile data base
+extern INT32 nCpsrScrX,nCpsrScrY;						// Basic scroll info
+extern UINT16 *CpsrRows;					// Row scroll table, 0x400 words long
+extern INT32 nCpsrRowStart;							// Start of row scroll (can wrap?)
 
 // Information needed to draw a line
 struct CpsrLineInfo {
-	int nStart;										// 0-0x3ff - where to start drawing tiles from
-	int nWidth;										// 0-0x400 - width of scroll shifts
+	INT32 nStart;										// 0-0x3ff - where to start drawing tiles from
+	INT32 nWidth;										// 0-0x400 - width of scroll shifts
 													// e.g. for no rowscroll at all, nWidth=0
-	int nTileStart;									// Range of tiles which are visible onscreen
-	int nTileEnd;									// (e.g. 0x20 -> 0x50 , wraps around to 0x10)
-	short Rows[16];									// 16 row scroll values for this line
-	int nMaxLeft, nMaxRight;						// Maximum row shifts left and right
+	INT32 nTileStart;									// Range of tiles which are visible onscreen
+	INT32 nTileEnd;									// (e.g. 0x20 -> 0x50 , wraps around to 0x10)
+	INT16 Rows[16];									// 16 row scroll values for this line
+	INT32 nMaxLeft, nMaxRight;						// Maximum row shifts left and right
 };
 extern struct CpsrLineInfo CpsrLineInfo[15];
-int Cps1rPrepare();
-int Cps2rPrepare();
+INT32 Cps1rPrepare();
+INT32 Cps2rPrepare();
 
 // cpsrd.cpp
-int Cps1rRender();
-int Cps2rRender();
+INT32 Cps1rRender();
+INT32 Cps2rRender();
 
 // dc_input.cpp
 extern struct BurnInputInfo CpsFsi[0x1B];
 
 // ps.cpp
-extern unsigned char PsndCode, PsndFade;			// Sound code/fade sent to the z80 program
-int PsndInit();
-int PsndExit();
+extern UINT8 PsndCode, PsndFade;			// Sound code/fade sent to the z80 program
+INT32 PsndInit();
+INT32 PsndExit();
 void PsndNewFrame();
-int PsndSyncZ80(int nCycles);
-int PsndScan(int nAction);
+INT32 PsndSyncZ80(INT32 nCycles);
+INT32 PsndScan(INT32 nAction, INT32 *pnMin);
 
 // ps_z.cpp
-int PsndZInit();
-int PsndZExit();
-int PsndZScan(int nAction);
-extern int Kodb;
+INT32 PsndZInit();
+INT32 PsndZExit();
+INT32 PsndZScan(INT32 nAction, INT32 *pnMin);
+extern INT32 Kodb;
 
 // ps_m.cpp
-extern int bPsmOkay;								// 1 if the module is okay
-int PsmInit();
-int PsmExit();
+extern INT32 bPsmOkay;								// 1 if the module is okay
+INT32 PsmInit();
+INT32 PsmExit();
 void PsmNewFrame();
-int PsmUpdate(int nEnd);
+INT32 PsmUpdate(INT32 nEnd);
 
 // kabuki.cpp
 void wof_decode();
@@ -369,3 +469,42 @@ void slammast_decode();
 
 // cps2_crypt.cpp
 void cps2_decrypt_game_data();
+
+// fcrash_snd.cpp
+void FcrashSoundCommand(UINT16 d);
+INT32 FcrashSoundInit();
+INT32 FcrashSoundReset();
+INT32 FcrashSoundExit();
+void FcrashSoundFrameStart();
+void FcrashSoundFrameEnd();
+INT32 FcrashScanSound(INT32 nAction, INT32 *pnMin);
+
+// sf2mdt_snd.cpp
+void Sf2mdtSoundCommand(UINT16 d);
+INT32 Sf2mdtSoundInit();
+INT32 Sf2mdtSoundReset();
+INT32 Sf2mdtSoundExit();
+void Sf2mdtSoundFrameStart();
+void Sf2mdtSoundFrameEnd();
+INT32 Sf2mdtScanSound(INT32 nAction, INT32 *pnMin);
+
+// d_cps2.cpp
+#define CPS2_PRG_68K						1
+#define CPS2_PRG_68K_SIMM					2
+#define CPS2_PRG_68K_XOR_TABLE				3
+#define CPS2_GFX							5
+#define CPS2_GFX_SIMM						6
+#define CPS2_GFX_SPLIT4						7
+#define CPS2_GFX_SPLIT8						8
+#define CPS2_GFX_19XXJ						9
+#define CPS2_PRG_Z80						10
+#define CPS2_QSND							12
+#define CPS2_QSND_SIMM						13
+#define CPS2_QSND_SIMM_BYTESWAP				14
+#define CPS2_ENCRYPTION_KEY					15
+
+extern INT32 Cps2Volume;
+extern UINT16 Cps2VolumeStates[40];
+extern INT32 Cps2DisableDigitalVolume;
+extern UINT8 Cps2VolUp;
+extern UINT8 Cps2VolDwn;

--- a/src/burn/capcom/cps.h
+++ b/src/burn/capcom/cps.h
@@ -244,21 +244,6 @@ void QscNewFrame();
 void QscWrite(int a, int d);
 int QscUpdate(int nEnd);
 
-// Sound outputs
-#define BURN_SND_QSND_OUTPUT_1			0
-#define BURN_SND_QSND_OUTPUT_2			1
-
-// Sound clipping macro
-#define BURN_SND_CLIP(A) ((A) < -0x8000 ? -0x8000 : (A) > 0x7fff ? 0x7fff : (A))
-
-// Sound routes
-#define BURN_SND_ROUTE_LEFT			1
-#define BURN_SND_ROUTE_RIGHT		2
-#define BURN_SND_ROUTE_BOTH			(BURN_SND_ROUTE_LEFT | BURN_SND_ROUTE_RIGHT)
-
-// Macro to determine the size of a struct up to and including "member"
-#define STRUCT_SIZE_HELPER(type, member) offsetof(type, member) + sizeof(((type*)0)->member)
-
 // cps_tile.cpp
 extern unsigned int* CpstPal;
 extern unsigned int nCpstType; extern int nCpstX,nCpstY;

--- a/src/burn/capcom/qs.cpp
+++ b/src/burn/capcom/qs.cpp
@@ -39,11 +39,8 @@ int QsndInit()
 	nVolumeShift = 0;
 
 	// These games are too soft at normal volumes
-	if (strncmp(BurnDrvGetTextA(DRV_NAME), "punisher", 8) == 0) {
-		nVolumeShift = 2;
-	}
 	if (strncmp(BurnDrvGetTextA(DRV_NAME), "csclub", 6) == 0) {
-		nVolumeShift = 1;
+		nVolumeShift = -1;
 	}
 #if 0
 	// These games are loud at normal volumes (no clipping)
@@ -51,7 +48,7 @@ int QsndInit()
 		strcmp( BurnDrvGetTextA(DRV_NAME), "dimahoo"  ) == 0 ||
 		strcmp( BurnDrvGetTextA(DRV_NAME), "gmahoo"   ) == 0)
 	{
-		nVolumeShift = -1;
+		nVolumeShift = 1;
 	}
 #endif
 	// These games are too loud at normal volumes (no clipping)
@@ -62,13 +59,13 @@ int QsndInit()
 		strncmp(BurnDrvGetTextA(DRV_NAME), "sfa2",   4) == 0 ||
 		strncmp(BurnDrvGetTextA(DRV_NAME), "sfa2",   4) == 0)
 	{
-		nVolumeShift = -1;
+		nVolumeShift = 1;
 	}
 	// These games are too loud at normal volumes (clipping)
 	if (strncmp(BurnDrvGetTextA(DRV_NAME), "19xx",   4) == 0 ||
 		strncmp(BurnDrvGetTextA(DRV_NAME), "ddtod",  5) == 0)
 	{
-		nVolumeShift = -2;
+		nVolumeShift = 2;
 	}
 
 	QscInit(nRate, nVolumeShift);		// Init QSound chip
@@ -121,7 +118,7 @@ void QsndEndFrame()
 
 void QsndSyncZ80()
 {
-	int nCycles = (long long int)SekTotalCycles() * nCpsZ80Cycles / nCpsCycles;
+	int nCycles = (long long)SekTotalCycles() * nCpsZ80Cycles / nCpsCycles;
 
 	if (nCycles <= ZetTotalCycles()) {
 		return;

--- a/src/burn/capcom/qs.cpp
+++ b/src/burn/capcom/qs.cpp
@@ -6,7 +6,7 @@ static INT32 nQsndCyclesExtra;
 static INT32 qsndTimerOver(INT32, INT32)
 {
 //	bprintf(PRINT_NORMAL, _T("  - IRQ -> 1.\n"));
-	ZetSetIRQLine(0xFF, CPU_IRQSTATUS_HOLD);
+	ZetSetIRQLine(0xFF, CPU_IRQSTATUS_AUTO);
 
 	return 0;
 }
@@ -22,8 +22,8 @@ INT32 QsndInit()
 	BurnTimerInit(qsndTimerOver, NULL);
 
 	if (Cps1Qs == 1) {
-		nCpsZ80Cycles = 8000000 * 100 / nBurnFPS;
-		BurnTimerAttachZet(8000000);
+		nCpsZ80Cycles = 6000000 * 100 / nBurnFPS;
+		BurnTimerAttachZet(6000000);
 	} else {
 		nCpsZ80Cycles = 8000000 * 100 / nBurnFPS;
 		BurnTimerAttachZet(8000000);
@@ -66,9 +66,6 @@ INT32 QsndScan(INT32 nAction)
 	if (nAction & ACB_DRIVER_DATA) {
 		QsndZScan(nAction);				// Scan Z80
 		QscScan(nAction);				// Scan QSound Chip
-
-		BurnTimerScan(nAction, NULL);
-		SCAN_VAR(nQsndCyclesExtra);
 	}
 
 	return 0;

--- a/src/burn/capcom/qs.cpp
+++ b/src/burn/capcom/qs.cpp
@@ -6,7 +6,7 @@ static INT32 nQsndCyclesExtra;
 static INT32 qsndTimerOver(INT32, INT32)
 {
 //	bprintf(PRINT_NORMAL, _T("  - IRQ -> 1.\n"));
-	ZetSetIRQLine(0xFF, CPU_IRQSTATUS_AUTO);
+	ZetSetIRQLine(0xFF, ZET_IRQSTATUS_AUTO);
 
 	return 0;
 }
@@ -92,7 +92,7 @@ void QsndEndFrame()
 
 void QsndSyncZ80()
 {
-	int nCycles = (INT64)SekTotalCycles() * nCpsZ80Cycles / nCpsCycles;
+	int nCycles = (long long)SekTotalCycles() * nCpsZ80Cycles / nCpsCycles;
 
 	if (nCycles <= ZetTotalCycles()) {
 		return;

--- a/src/burn/capcom/qs.cpp
+++ b/src/burn/capcom/qs.cpp
@@ -37,7 +37,7 @@ int QsndInit()
 	}
 
 	nVolumeShift = 0;
-#ifdef QSOUND_FBNEO
+#ifdef USE_QSOUND_FBNEO
 	// These games are too soft at normal volumes
 	if (strncmp(BurnDrvGetTextA(DRV_NAME), "punisher", 8) == 0) {
 		nVolumeShift = 2;
@@ -84,12 +84,12 @@ void QsndSetRoute(INT32 nIndex, double nVolume, INT32 nRouteDir)
 
 void QsndReset()
 {
-#ifndef QSOUND_FBNEO
+#ifndef USE_QSOUND_FBNEO
 	ZetOpen(0);
 #endif
 	BurnTimerReset();
 	BurnTimerSetRetrig(0, 1.0 / 252.0);
-#ifndef QSOUND_FBNEO
+#ifndef USE_QSOUND_FBNEO
 	ZetClose();
 #endif
 
@@ -133,7 +133,7 @@ void QsndEndFrame()
 
 void QsndSyncZ80()
 {
-#ifdef QSOUND_FBNEO
+#ifdef USE_QSOUND_FBNEO
 	int nCycles = (long long int)SekTotalCycles() * nCpsZ80Cycles / nCpsCycles;
 #else
 	int nCycles = (long long)SekTotalCycles() * nCpsZ80Cycles / nCpsCycles;

--- a/src/burn/capcom/qs_c.cpp
+++ b/src/burn/capcom/qs_c.cpp
@@ -1,786 +1,136 @@
-/*
-
-	Capcom DL-1425 QSound emulator
-	==============================
-
-	by superctr (Ian Karlsson)
-	with thanks to Valley Bell
-
-	2018-05-12 - 2018-05-15
-
-*/
+// QSound - emulator for the QSound Chip
 
 #include <math.h>
-#include <stddef.h>
-#include <string.h>	// for memset
 #include "cps.h"
 #include "burn_sound.h"
 
-static const INT32 nQscClock = 60000000;
-static const INT32 nQscClockDivider = 2496;
+static const int nQscClock = 4000000;
+static const int nQscClockDivider = 166;
 
-static INT32 nQscRate = 0;
-//static float nQscVolumeShift;
+static int nQscRate = 0;
+static int nQscVolumeShift;
 
-static INT32 nPos;
-static INT32 nDelta;
+static int Tams = -1;
+static int* Qs_s = NULL;
 
-static double QsndGain[2];
-static INT32 QsndOutputDir[2];
+static int nPos;
 
-#define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
+struct QChan {
+		unsigned char bKey;				// 1 if channel is playing
+		char nBank;						// Bank we are currently playing a sample from
 
-struct qsound_voice {
-	UINT16 bank;
-	INT16 addr; // top word is the sample address
-	UINT16 phase;
-	UINT16 rate;
-	INT16 loop_len;
-	INT16 end_addr;
-	INT16 volume;
-	INT16 echo;
+		char* PlayBank;					// Pointer to current bank
+
+		int nPlayStart;					// Start of being played
+		int nStart;						// Start of sample 16.12
+		int nEnd;						// End of sample   16.12
+		int nLoop;						// Loop offset from end
+		int nPos;						// Current position within the bank 16.12
+		int nAdvance;					// Sample size
+
+		int nMasterVolume;				// Master volume for the channel
+		int nVolume[2];					// Left & right side volumes (panning)
+
+		int nPitch;						// Playback frequency
+
+		char nEndBuffer[8];				// Buffer to enable correct cubic interpolation
 };
 
-struct qsound_adpcm {
-	UINT16 start_addr;
-	UINT16 end_addr;
-	UINT16 bank;
-	INT16 volume;
-	UINT16 flag;
-	INT16 cur_vol;
-	INT16 step_size;
-	UINT16 cur_addr;
-};
+static struct QChan QChan[16];
 
-// Q1 Filter
-struct qsound_fir {
-	int tap_count;	// usually 95
-	int delay_pos;
-	INT16 table_pos;
-	INT16 taps[95];
-	INT16 delay_line[95];
-};
+static int PanningVolumes[33];
 
-// Delay line
-struct qsound_delay {
-	INT16 delay;
-	INT16 volume;
-	INT16 write_pos;
-	INT16 read_pos;
-	INT16 delay_line[51];
-};
-
-struct qsound_echo {
-	UINT16 end_pos;
-
-	INT16 feedback;
-	INT16 length;
-	INT16 last_sample;
-	INT16 delay_line[1024];
-	INT16 delay_pos;
-};
-
-struct qsound_chip {
-	INT16 out[2];
-
-	struct qsound_voice voice[16];
-	struct qsound_adpcm adpcm[3];
-
-	UINT16 voice_pan[16+3];
-	INT16 voice_output[16+3];
-
-	struct qsound_echo echo;
-
-	struct qsound_fir filter[2];
-	struct qsound_fir alt_filter[2];
-
-	struct qsound_delay wet[2];
-	struct qsound_delay dry[2];
-
-	UINT16 state;
-	UINT16 next_state;
-
-	UINT16 delay_update;
-
-	int state_counter;
-	UINT8 ready_flag;
-};
-
-static UINT16 *register_map[256];
-static INT16 pan_tables[2][2][98];
-
-static INT16 interpolate_buffer[2][4];
-
-static void init_pan_tables();
-static void init_register_map();
-static void update_sample();
-
-static void state_init();
-static void state_refresh_filter_1();
-static void state_refresh_filter_2();
-static void state_normal_update();
-
-static inline INT16 get_sample(UINT16 bank,UINT16 address);
-static inline const INT16* get_filter_table(UINT16 offset);
-static inline INT16 pcm_update(int voice_no, INT32 *echo_out);
-static inline void adpcm_update(int voice_no, int nibble);
-static inline INT16 echo(struct qsound_echo *r,INT32 input);
-static inline INT32 fir(struct qsound_fir *f, INT16 input);
-static inline INT32 delay(struct qsound_delay *d, INT32 input);
-static inline void delay_update(struct qsound_delay *d);
-
-static qsound_chip chip;
-
-static const INT16 qsound_dry_mix_table[33] = {
-	-16384,-16384,-16384,-16384,-16384,-16384,-16384,-16384,
-	-16384,-16384,-16384,-16384,-16384,-16384,-16384,-16384,
-	-16384,-14746,-13107,-11633,-10486,-9175,-8520,-7209,
-	-6226,-5226,-4588,-3768,-3277,-2703,-2130,-1802,
-	0
-};
-
-static const INT16 qsound_wet_mix_table[33] = {
-	0,-1638,-1966,-2458,-2949,-3441,-4096,-4669,
-	-4915,-5120,-5489,-6144,-7537,-8831,-9339,-9830,
-	-10240,-10322,-10486,-10568,-10650,-11796,-12288,-12288,
-	-12534,-12648,-12780,-12829,-12943,-13107,-13418,-14090,
-	-16384
-};
-
-static const INT16 qsound_linear_mix_table[33] = {
-	-16379,-16338,-16257,-16135,-15973,-15772,-15531,-15251,
-	-14934,-14580,-14189,-13763,-13303,-12810,-12284,-11729,
-	-11729,-11144,-10531,-9893,-9229,-8543,-7836,-7109,
-	-6364,-5604,-4829,-4043,-3246,-2442,-1631,-817,
-	0
-};
-
-static const INT16 qsound_filter_data[5][95] = {
-	{	// d53 - 0
-		0,0,0,6,44,-24,-53,-10,59,-40,-27,1,39,-27,56,127,174,36,-13,49,
-		212,142,143,-73,-20,66,-108,-117,-399,-265,-392,-569,-473,-71,95,-319,-218,-230,331,638,
-		449,477,-180,532,1107,750,9899,3828,-2418,1071,-176,191,-431,64,117,-150,-274,-97,-238,165,
-		166,250,-19,4,37,204,186,-6,140,-77,-1,1,18,-10,-151,-149,-103,-9,55,23,
-		-102,-97,-11,13,-48,-27,5,18,-61,-30,64,72,0,0,0,
-	},
-	{	// db2 - 1 - default left filter
-		0,0,0,85,24,-76,-123,-86,-29,-14,-20,-7,6,-28,-87,-89,-5,100,154,160,
-		150,118,41,-48,-78,-23,59,83,-2,-176,-333,-344,-203,-66,-39,2,224,495,495,280,
-		432,1340,2483,5377,1905,658,0,97,347,285,35,-95,-78,-82,-151,-192,-171,-149,-147,-113,
-		-22,71,118,129,127,110,71,31,20,36,46,23,-27,-63,-53,-21,-19,-60,-92,-69,
-		-12,25,29,30,40,41,29,30,46,39,-15,-74,0,0,0,
-	},
-	{	// e11 - 2 - default right filter
-		0,0,0,23,42,47,29,10,2,-14,-54,-92,-93,-70,-64,-77,-57,18,94,113,
-		87,69,67,50,25,29,58,62,24,-39,-131,-256,-325,-234,-45,58,78,223,485,496,
-		127,6,857,2283,2683,4928,1328,132,79,314,189,-80,-90,35,-21,-186,-195,-99,-136,-258,
-		-189,82,257,185,53,41,84,68,38,63,77,14,-60,-71,-71,-120,-151,-84,14,29,
-		-8,7,66,69,12,-3,54,92,52,-6,-15,-2,0,0,0,
-	},
-	{	// e70 - 3
-		0,0,0,2,-28,-37,-17,0,-9,-22,-3,35,52,39,20,7,-6,2,55,121,
-		129,67,8,1,9,-6,-16,16,66,96,118,130,75,-47,-92,43,223,239,151,219,
-		440,475,226,206,940,2100,2663,4980,865,49,-33,186,231,103,42,114,191,184,116,29,
-		-47,-72,-21,60,96,68,31,32,63,87,76,39,7,14,55,85,67,18,-12,-3,
-		21,34,29,6,-27,-49,-37,-2,16,0,-21,-16,0,0,0,
-	},
-	{	// ecf - 4
-		0,0,0,48,7,-22,-29,-10,24,54,59,29,-36,-117,-185,-213,-185,-99,13,90,
-		83,24,-5,23,53,47,38,56,67,57,75,107,16,-242,-440,-355,-120,-33,-47,152,
-		501,472,-57,-292,544,1937,2277,6145,1240,153,47,200,152,36,64,134,74,-82,-208,-266,
-		-268,-188,-42,65,74,56,89,133,114,44,-3,-1,17,29,29,-2,-76,-156,-187,-151,
-		-85,-31,-5,7,20,32,24,-5,-20,6,48,62,0,0,0,
-	}
-};
-
-static const INT16 qsound_filter_data2[209] = {
-	// f2e - following 95 values used for "disable output" filter
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,0,0,0,
-
-	// f73 - following 45 values used for "mode 2" filter (overlaps with f2e)
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,
-	-371,-196,-268,-512,-303,-315,-184,-76,276,-256,298,196,990,236,1114,-126,4377,6549,791,
-
-	// fa0 - filtering disabled (for 95-taps) (use fa3 or fa4 for mode2 filters)
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,0,-16384,0,0,0,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-};
-
-static const INT16 adpcm_step_table[16] = {
-	154, 154, 128, 102, 77, 58, 58, 58,
-	58, 58, 58, 58, 77, 102, 128, 154
-};
-
-// DSP states
-enum {
-	STATE_INIT1		= 0x288,
-	STATE_INIT2		= 0x61a,
-	STATE_REFRESH1	= 0x039,
-	STATE_REFRESH2	= 0x04f,
-	STATE_NORMAL1	= 0x314,
-	STATE_NORMAL2 	= 0x6b2
-};
-
-enum {
-	PANTBL_LEFT		= 0,
-	PANTBL_RIGHT	= 1,
-	PANTBL_DRY		= 0,
-	PANTBL_WET		= 1
-};
-
-static void init_pan_tables()
+static void MapBank(struct QChan* pc)
 {
-	int i;
-	for(i=0;i<33;i++)
-	{
-		// dry mixing levels
-		pan_tables[PANTBL_LEFT][PANTBL_DRY][i] = qsound_dry_mix_table[i];
-		pan_tables[PANTBL_RIGHT][PANTBL_DRY][i] = qsound_dry_mix_table[32-i];
-		// wet mixing levels
-		pan_tables[PANTBL_LEFT][PANTBL_WET][i] = qsound_wet_mix_table[i];
-		pan_tables[PANTBL_RIGHT][PANTBL_WET][i] = qsound_wet_mix_table[32-i];
-		// linear panning, only for dry component. wet component is muted.
-		pan_tables[PANTBL_LEFT][PANTBL_DRY][i+0x30] = qsound_linear_mix_table[i];
-		pan_tables[PANTBL_RIGHT][PANTBL_DRY][i+0x30] = qsound_linear_mix_table[32-i];
+	unsigned int nBank;
+
+	nBank = (pc->nBank & 0x7F) << 16;	// Banks are 0x10000 samples long
+
+	// Confirm whole bank is in range:
+	// If bank is out of range use bank 0 instead
+	if ((nBank + 0x10000) > nCpsQSamLen) {
+		nBank = 0;
 	}
+	pc->PlayBank = (char*)CpsQSam + nBank;
 }
 
-static void init_register_map()
+static void UpdateEndBuffer(struct QChan* pc)
 {
-	int i;
-
-	// unused registers
-	for(i=0;i<256;i++)
-		register_map[i] = NULL;
-
-	// PCM registers
-	for(i=0;i<16;i++) // PCM voices
-	{
-		register_map[(i<<3)+0] = (UINT16*)&chip.voice[(i+1)%16].bank; // Bank applies to the next channel
-		register_map[(i<<3)+1] = (UINT16*)&chip.voice[i].addr; // Current sample position and start position.
-		register_map[(i<<3)+2] = (UINT16*)&chip.voice[i].rate; // 4.12 fixed point decimal.
-		register_map[(i<<3)+3] = (UINT16*)&chip.voice[i].phase;
-		register_map[(i<<3)+4] = (UINT16*)&chip.voice[i].loop_len;
-		register_map[(i<<3)+5] = (UINT16*)&chip.voice[i].end_addr;
-		register_map[(i<<3)+6] = (UINT16*)&chip.voice[i].volume;
-		register_map[(i<<3)+7] = NULL;	// unused
-		register_map[i+0x80] = (UINT16*)&chip.voice_pan[i];
-		register_map[i+0xba] = (UINT16*)&chip.voice[i].echo;
-	}
-
-	// ADPCM registers
-	for(i=0;i<3;i++) // ADPCM voices
-	{
-		// ADPCM sample rate is fixed to 8khz. (one channel is updated every third sample)
-		register_map[(i<<2)+0xca] = (UINT16*)&chip.adpcm[i].start_addr;
-		register_map[(i<<2)+0xcb] = (UINT16*)&chip.adpcm[i].end_addr;
-		register_map[(i<<2)+0xcc] = (UINT16*)&chip.adpcm[i].bank;
-		register_map[(i<<2)+0xcd] = (UINT16*)&chip.adpcm[i].volume;
-		register_map[i+0xd6] = (UINT16*)&chip.adpcm[i].flag; // non-zero to start ADPCM playback
-		register_map[i+0x90] = (UINT16*)&chip.voice_pan[16+i];
-	}
-
-	// QSound registers
-	register_map[0x93] = (UINT16*)&chip.echo.feedback;
-	register_map[0xd9] = (UINT16*)&chip.echo.end_pos;
-	register_map[0xe2] = (UINT16*)&chip.delay_update; // non-zero to update delays
-	register_map[0xe3] = (UINT16*)&chip.next_state;
-	for(i=0;i<2;i++)  // left, right
-	{
-		// Wet
-		register_map[(i<<1)+0xda] = (UINT16*)&chip.filter[i].table_pos;
-		register_map[(i<<1)+0xde] = (UINT16*)&chip.wet[i].delay;
-		register_map[(i<<1)+0xe4] = (UINT16*)&chip.wet[i].volume;
-		// Dry
-		register_map[(i<<1)+0xdb] = (UINT16*)&chip.alt_filter[i].table_pos;
-		register_map[(i<<1)+0xdf] = (UINT16*)&chip.dry[i].delay;
-		register_map[(i<<1)+0xe5] = (UINT16*)&chip.dry[i].volume;
-	}
-}
-
-inline INT16 get_sample(UINT16 bank, UINT16 address)
-{
-	UINT32 rom_addr;
-	UINT32 rom_mask = 0;
-	UINT8 sample_data;
-
-	if(nCpsQSamLen)
-		rom_mask = nCpsQSamLen - 1;
-
-	if (! rom_mask)
-		return 0;	// no ROM loaded
-	if (! (bank & 0x8000))
-		return 0;	// ignore attempts to read from DSP program ROM
-
-	bank &= 0x7FFF;
-	rom_addr = (bank << 16) | (address << 0);
-
-	sample_data = CpsQSam[rom_addr & rom_mask];
-
-	return (INT16)((sample_data << 8) & 0xff00);
-}
-
-static inline const INT16* get_filter_table(UINT16 offset)
-{
-	int index;
-
-	if (offset >= 0xf2e && offset < 0xfff)
-		return &qsound_filter_data2[offset-0xf2e];	// overlapping filter data
-
-	index = (offset-0xd53)/95;
-	if(index >= 0 && index < 5)
-		return qsound_filter_data[index];	// normal tables
-
-	return NULL;	// no filter found.
-}
-
-/********************************************************************/
-
-// updates one DSP sample
-static void update_sample()
-{
-	switch(chip.state)
-	{
-		default:
-		case STATE_INIT1:
-		case STATE_INIT2:
-			state_init();
-			return;
-		case STATE_REFRESH1:
-			state_refresh_filter_1();
-			return;
-		case STATE_REFRESH2:
-			state_refresh_filter_2();
-			return;
-		case STATE_NORMAL1:
-		case STATE_NORMAL2:
-			state_normal_update();
-			return;
-	}
-}
-
-// Initialization routine
-static void state_init()
-{
-	int mode = (chip.state == STATE_INIT2) ? 1 : 0;
-	int i;
-
-	// we're busy for 4 samples, including the filter refresh.
-	if(chip.state_counter >= 2)
-	{
-		chip.state_counter = 0;
-		chip.state = chip.next_state;
-		return;
-	}
-	else if(chip.state_counter == 1)
-	{
-		chip.state_counter++;
-		return;
-	}
-
-	memset(chip.voice, 0, sizeof(chip.voice));
-	memset(chip.adpcm, 0, sizeof(chip.adpcm));
-	memset(chip.filter, 0, sizeof(chip.filter));
-	memset(chip.alt_filter, 0, sizeof(chip.alt_filter));
-	memset(chip.wet, 0, sizeof(chip.wet));
-	memset(chip.dry, 0, sizeof(chip.dry));
-	memset(&chip.echo, 0, sizeof(chip.echo));
-
-	for(i=0;i<19;i++)
-	{
-		chip.voice_pan[i] = 0x120;
-		chip.voice_output[i] = 0;
-	}
-
-	for(i=0;i<16;i++)
-		chip.voice[i].bank = 0x8000;
-	for(i=0;i<3;i++)
-		chip.adpcm[i].bank = 0x8000;
-
-	if(mode == 0)
-	{
-		// mode 1
-		chip.wet[0].delay = 0;
-		chip.dry[0].delay = 46;
-		chip.wet[1].delay = 0;
-		chip.dry[1].delay = 48;
-		chip.filter[0].table_pos = 0xdb2;
-		chip.filter[1].table_pos = 0xe11;
-		chip.echo.end_pos = 0x554 + 6;
-		chip.next_state = STATE_REFRESH1;
-	}
-	else
-	{
-		// mode 2
-		chip.wet[0].delay = 1;
-		chip.dry[0].delay = 0;
-		chip.wet[1].delay = 0;
-		chip.dry[1].delay = 0;
-		chip.filter[0].table_pos = 0xf73;
-		chip.filter[1].table_pos = 0xfa4;
-		chip.alt_filter[0].table_pos = 0xf73;
-		chip.alt_filter[1].table_pos = 0xfa4;
-		chip.echo.end_pos = 0x53c + 6;
-		chip.next_state = STATE_REFRESH2;
-	}
-
-	chip.wet[0].volume = 0x3fff;
-	chip.dry[0].volume = 0x3fff;
-	chip.wet[1].volume = 0x3fff;
-	chip.dry[1].volume = 0x3fff;
-
-	chip.delay_update = 1;
-	chip.ready_flag = 0;
-	chip.state_counter = 1;
-}
-
-// Updates filter parameters for mode 1
-static void state_refresh_filter_1()
-{
-	const INT16 *table;
-	int ch;
-
-	for(ch=0; ch<2; ch++)
-	{
-		chip.filter[ch].delay_pos = 0;
-		chip.filter[ch].tap_count = 95;
-
-		table = get_filter_table(chip.filter[ch].table_pos);
-		if (table != NULL)
-			memcpy(chip.filter[ch].taps, table, 95 * sizeof(INT16));
-	}
-
-	chip.state = chip.next_state = STATE_NORMAL1;
-}
-
-// Updates filter parameters for mode 2
-static void state_refresh_filter_2()
-{
-	const INT16 *table;
-	int ch;
-
-	for(ch=0; ch<2; ch++)
-	{
-		chip.filter[ch].delay_pos = 0;
-		chip.filter[ch].tap_count = 45;
-
-		table = get_filter_table(chip.filter[ch].table_pos);
-		if (table != NULL)
-			memcpy(chip.filter[ch].taps, table, 45 * sizeof(INT16));
-
-		chip.alt_filter[ch].delay_pos = 0;
-		chip.alt_filter[ch].tap_count = 44;
-
-		table = get_filter_table(chip.alt_filter[ch].table_pos);
-		if (table != NULL)
-			memcpy(chip.alt_filter[ch].taps, table, 44 * sizeof(INT16));
-	}
-
-	chip.state = chip.next_state = STATE_NORMAL2;
-}
-
-// Updates a PCM voice. There are 16 voices, each are updated every sample
-// with full rate and volume control.
-static inline INT16 pcm_update(int voice_no, INT32 *echo_out)
-{
-	struct qsound_voice *v = &chip.voice[voice_no];
-	INT32 new_phase;
-	INT16 output;
-
-	// Read sample from rom and apply volume
-	output = (v->volume * get_sample(v->bank, v->addr))>>14;
-
-	*echo_out += (output * v->echo)<<2;
-
-	// Add delta to the phase and loop back if required
-	new_phase = v->rate + ((v->addr<<12) | (v->phase>>4));
-
-	if((new_phase>>12) >= v->end_addr)
-		new_phase -= (v->loop_len<<12);
-
-	new_phase = CLAMP(new_phase, -0x8000000, 0x7FFFFFF);
-	v->addr = new_phase>>12;
-	v->phase = (new_phase<<4)&0xffff;
-
-	return output;
-}
-
-// Updates an ADPCM voice. There are 3 voices, one is updated every sample
-// (effectively making the ADPCM rate 1/3 of the master sample rate), and
-// volume is set when starting samples only.
-// The ADPCM algorithm is supposedly similar to Yamaha ADPCM. It also seems
-// like Capcom never used it, so this was not emulated in the earlier QSound
-// emulators.
-static inline void adpcm_update(int voice_no, int nibble)
-{
-	struct qsound_adpcm *v = &chip.adpcm[voice_no];
-
-	INT32 delta;
-	INT8 step;
-
-	if(!nibble)
-	{
-		// Mute voice when it reaches the end address.
-		if(v->cur_addr == v->end_addr)
-			v->cur_vol = 0;
-
-		// Playback start flag
-		if(v->flag)
-		{
-			chip.voice_output[16+voice_no] = 0;
-			v->flag = 0;
-			v->step_size = 10;
-			v->cur_vol = v->volume;
-			v->cur_addr = v->start_addr;
-		}
-
-		// get top nibble
-		step = get_sample(v->bank, v->cur_addr) >> 8;
-	}
-	else
-	{
-		// get bottom nibble
-		step = get_sample(v->bank, v->cur_addr++) >> 4;
-	}
-
-	// shift with sign extend
-	step >>= 4;
-
-	// delta = (0.5 + abs(v->step)) * v->step_size
-	delta = ((1+abs(step<<1)) * v->step_size)>>1;
-	if(step <= 0)
-		delta = -delta;
-	delta += chip.voice_output[16+voice_no];
-	delta = CLAMP(delta,-32768,32767);
-
-	chip.voice_output[16+voice_no] = (delta * v->cur_vol)>>16;
-
-	v->step_size = (adpcm_step_table[8+step] * v->step_size) >> 6;
-	v->step_size = CLAMP(v->step_size, 1, 2000);
-}
-
-// The echo effect is pretty simple. A moving average filter is used on
-// the output from the delay line to smooth samples over time.
-static inline INT16 echo(struct qsound_echo *r,INT32 input)
-{
-	// get average of last 2 samples from the delay line
-	INT32 new_sample;
-	INT32 old_sample = r->delay_line[r->delay_pos];
-	INT32 last_sample = r->last_sample;
-
-	r->last_sample = old_sample;
-	old_sample = (old_sample+last_sample) >> 1;
-
-	// add current sample to the delay line
-	new_sample = input + ((old_sample * r->feedback)<<2);
-	r->delay_line[r->delay_pos++] = new_sample>>16;
-
-	if(r->delay_pos >= r->length)
-		r->delay_pos = 0;
-
-	return old_sample;
-}
-
-// Process a sample update
-static void state_normal_update()
-{
-	int v, ch;
-	INT32 echo_input = 0;
-	INT16 echo_output;
-
-	chip.ready_flag = 0x80;
-
-	// recalculate echo length
-	if(chip.state == STATE_NORMAL2)
-		chip.echo.length = chip.echo.end_pos - 0x53c;
-	else
-		chip.echo.length = chip.echo.end_pos - 0x554;
-
-	chip.echo.length = CLAMP(chip.echo.length, 0, 1024);
-
-	// update PCM voices
-	for(v=0; v<16; v++)
-		chip.voice_output[v] = pcm_update(v, &echo_input);
-
-	// update ADPCM voices (one every third sample)
-	adpcm_update(chip.state_counter % 3, chip.state_counter / 3);
-
-	echo_output = echo(&chip.echo,echo_input);
-
-	// now, we do the magic stuff
-	for(ch=0; ch<2; ch++)
-	{
-		// Echo is output on the unfiltered component of the left channel and
-		// the filtered component of the right channel.
-		INT32 wet = (ch == 1) ? echo_output<<14 : 0;
-		INT32 dry = (ch == 0) ? echo_output<<14 : 0;
-		INT32 output = 0;
-
-		for(v=0; v<19; v++)
-		{
-			UINT16 pan_index = chip.voice_pan[v]-0x110;
-			if(pan_index > 97)
-				pan_index = 97;
-
-			// Apply different volume tables on the dry and wet inputs.
-			dry -= (chip.voice_output[v] * pan_tables[ch][PANTBL_DRY][pan_index]);
-			wet -= (chip.voice_output[v] * pan_tables[ch][PANTBL_WET][pan_index]);
-		}
-
-		// Saturate accumulated voices
-		dry = CLAMP(dry, -0x1fffffff, 0x1fffffff) << 2;
-		wet = CLAMP(wet, -0x1fffffff, 0x1fffffff) << 2;
-
-		// Apply FIR filter on 'wet' input
-		wet = fir(&chip.filter[ch], wet >> 16);
-
-		// in mode 2, we do this on the 'dry' input too
-		if(chip.state == STATE_NORMAL2)
-			dry = fir(&chip.alt_filter[ch], dry >> 16);
-
-		// output goes through a delay line and attenuation
-		output = (delay(&chip.wet[ch], wet) + delay(&chip.dry[ch], dry));
-
-		// DSP round function
-		output = ((output + 0x2000) & ~0x3fff) >> 14;
-		chip.out[ch] = CLAMP(output, -0x7fff, 0x7fff);
-
-		if(chip.delay_update)
-		{
-			delay_update(&chip.wet[ch]);
-			delay_update(&chip.dry[ch]);
+	if (pc->bKey) {
+		// prepare a buffer to correctly interpolate the last 4 samples
+		if (nInterpolation >= 3) {
+			for (int i = 0; i < 4; i++) {
+				pc->nEndBuffer[i] = pc->PlayBank[(pc->nEnd >> 12) - 4 + i];
+			}
+
+			if (pc->nLoop) {
+				for (int i = 0, j = 0; i < 4; i++, j++) {
+					if (j >= (pc->nLoop >> 12)) {
+						j = 0;
+					}
+					pc->nEndBuffer[i + 4] = pc->PlayBank[((pc->nEnd - pc->nLoop) >> 12) + j];
+				}
+			} else {
+				for (int i = 0; i < 4; i++) {
+					pc->nEndBuffer[i + 4] = pc->nEndBuffer[3];
+				}
+			}
 		}
 	}
-
-	chip.delay_update = 0;
-
-	// after 6 samples, the next state is executed.
-	chip.state_counter++;
-	if(chip.state_counter > 5)
-	{
-		chip.state_counter = 0;
-		chip.state = chip.next_state;
-	}
 }
 
-// Apply the FIR filter used as the Q1 transfer function
-static inline INT32 fir(struct qsound_fir *f, INT16 input)
-{
-	INT32 output = 0, tap = 0;
-
-	for(; tap < (f->tap_count-1); tap++)
-	{
-		output -= (f->taps[tap] * f->delay_line[f->delay_pos++])<<2;
-
-		if(f->delay_pos >= f->tap_count-1)
-			f->delay_pos = 0;
-	}
-
-	output -= (f->taps[tap] * input)<<2;
-
-	f->delay_line[f->delay_pos++] = input;
-	if(f->delay_pos >= f->tap_count-1)
-		f->delay_pos = 0;
-
-	return output;
-}
-
-// Apply delay line and component volume
-static inline INT32 delay(struct qsound_delay *d, INT32 input)
-{
-	INT32 output;
-
-	d->delay_line[d->write_pos++] = input>>16;
-	if(d->write_pos >= 51)
-		d->write_pos = 0;
-
-	output = d->delay_line[d->read_pos++]*d->volume;
-	if(d->read_pos >= 51)
-		d->read_pos = 0;
-
-	return output;
-}
-
-// Update the delay read position to match new delay length
-static inline void delay_update(struct qsound_delay *d)
-{
-	INT16 new_read_pos = (d->write_pos - d->delay) % 51;
-	if(new_read_pos < 0)
-		new_read_pos += 51;
-
-	d->read_pos = new_read_pos;
-}
-
-//==========================================
-
-static long long int CalcAdvance()
+static void CalcAdvance(struct QChan* pc)
 {
 	if (nQscRate) {
-		return (long long int)0x1000 * nQscClock / nQscClockDivider / nQscRate;
+		pc->nAdvance = (long long)pc->nPitch * nQscClock / nQscClockDivider / nQscRate;
 	}
-	return 0;
 }
 
 void QscReset()
 {
-	chip.ready_flag = 0;
-	chip.out[0] = chip.out[1] = 0;
-	chip.state = 0;
-	chip.state_counter = 0;
-	nDelta = 0;
-	memset(interpolate_buffer, 0, sizeof(interpolate_buffer));
+	memset(QChan, 0, sizeof(QChan));
+
+	// Point all to bank 0
+	for (int i = 0; i < 16; i++) {
+		QChan[i].PlayBank = (char*)CpsQSam;
+	}
 }
 
 void QscExit()
 {
 	nQscRate = 0;
+
+	free(Qs_s);
+	Qs_s = NULL;
+	Tams = -1;
 }
 
-INT32 QscInit(INT32 nRate, INT32 nVolumeShift)
+int QscInit(int nRate, int nVolumeShift)
 {
 	nQscRate = nRate;
-	nDelta = 0;
 
-	//nQscVolumeShift = (10 + nVolumeShift) / 10;
+	nQscVolumeShift = 10 + nVolumeShift;
 
-	init_pan_tables();
-	init_register_map();
-
-	QsndGain[BURN_SND_QSND_OUTPUT_1] = 1.00;
-	QsndGain[BURN_SND_QSND_OUTPUT_2] = 1.00;
-	QsndOutputDir[BURN_SND_QSND_OUTPUT_1] = BURN_SND_ROUTE_LEFT;
-	QsndOutputDir[BURN_SND_QSND_OUTPUT_2] = BURN_SND_ROUTE_RIGHT;
+	for (int i = 0; i < 33; i++) {
+		PanningVolumes[i] = (int)((256.0 / sqrt(32.0)) * sqrt((double)i));
+	}
 
 	QscReset();
 
 	return 0;
 }
 
-void QscSetRoute(INT32 nIndex, double nVolume, INT32 nRouteDir)
+int QscScan(int nAction)
 {
-	QsndGain[nIndex] = nVolume;
-	QsndOutputDir[nIndex] = nRouteDir;
-}
+	SCAN_VAR(QChan);
 
-INT32 QscScan(INT32 nAction)
-{
-	struct BurnArea ba;
-	char szName[16];
-
-	sprintf(szName, "QSound");
-
-	ba.Data		= &chip;
-	ba.nLen		= STRUCT_SIZE_HELPER(struct qsound_chip, ready_flag);
-	ba.nAddress = 0;
-	ba.szName	= szName;
-	BurnAcb(&ba);
+	if (nAction & ACB_WRITE) {
+		// Update bank pointers with new banks, and recalc nAdvance
+		for (int i = 0; i < 16; i++) {
+			MapBank(QChan + i);
+			CalcAdvance(QChan + i);
+		}
+	}
 
 	return 0;
 }
@@ -795,24 +145,111 @@ static inline void QscSyncQsnd()
 	if (pBurnSoundOut) QscUpdate(ZetTotalCycles() * nBurnSoundLen / nCpsZ80Cycles);
 }
 
-void QscWrite(INT32 a, INT32 d)
+void QscWrite(int a, int d)
 {
-	UINT16 *destination = register_map[a];
+	struct QChan* pc;
+	int nChanNum, r;
+
+	// unknown
+	if (a >= 0x90) {
+//		bprintf(PRINT_NORMAL, "QSound: reg 0x%02X -> 0x%02X.\n", a, d);
+		return;
+	}
+
 	QscSyncQsnd();
-	if(destination)
-		*destination = d;
-	chip.ready_flag = 0;
+
+	if (a >= 0x80) {									// Set panning for channel
+		int nPan;
+
+		nChanNum = a & 15;
+
+		pc = QChan + nChanNum;		// Find channel
+		nPan = (d - 0x10) & 0x3F;	// nPan = 0x00 to 0x20 now
+		if (nPan > 0x20) {
+			nPan = 0x20;
+		}
+
+//		bprintf(PRINT_NORMAL, "QSound: ch#%i pan -> 0x%04X\n", nChanNum, d);
+
+		pc->nVolume[0] = PanningVolumes[0x20 - nPan];
+		pc->nVolume[1] = PanningVolumes[0x00 + nPan];
+
+		return;
+	}
+
+	// Get channel and register number
+	nChanNum = (a >> 3) & 15;
+	r = a & 7;
+
+	// Pointer to channel info
+	pc = QChan + nChanNum;
+
+	switch (r) {
+		case 0: {										// Set bank
+			// Strange but true
+			pc = QChan + ((nChanNum + 1) & 15);
+			pc->nBank = d;
+			MapBank(pc);
+			UpdateEndBuffer(pc);
+			break;
+		}
+		case 1: {										// Set sample start offset
+			pc->nStart = d << 12;
+			break;
+		}
+		case 2: {
+			pc->nPitch = d;
+			CalcAdvance(pc);
+
+			if (d == 0) {								// Key off; stop playing
+				pc->bKey = 0;
+			}
+
+			break;
+		}
+#if 0
+		case 3: {
+			break;
+		}
+#endif
+		case 4: {										// Set sample loop offset
+			pc->nLoop = d << 12;
+			UpdateEndBuffer(pc);
+			break;
+		}
+		case 5: {										// Set sample end offset
+			pc->nEnd = d << 12;
+			UpdateEndBuffer(pc);
+			break;
+		}
+		case 6: {										// Set volume
+			pc->nMasterVolume = d;
+
+			if (d == 0) {
+				pc->bKey = 0;
+			} else {
+				if (pc->bKey == 0) {					// Key on; play sample
+					pc->nPlayStart = pc->nStart;
+
+					pc->nPos = 0;
+					pc->bKey = 3;
+					UpdateEndBuffer(pc);
+				}
+			}
+			break;
+		}
+#if 0
+		case 7: {
+			break;
+		}
+#endif
+
+	}
 }
 
-UINT8 QscRead()
+int QscUpdate(int nEnd)
 {
-	QscSyncQsnd();
-	return chip.ready_flag;
-}
-
-INT32 QscUpdate(INT32 nEnd)
-{
-	INT32 nLen;
+	int nLen;
 
 	if (nEnd > nBurnSoundLen) {
 		nEnd = nBurnSoundLen;
@@ -824,96 +261,196 @@ INT32 QscUpdate(INT32 nEnd)
 		return 0;
 	}
 
+	if (Tams < nLen) {
+		if (Qs_s) {
+			free(Qs_s);
+		}
+		Tams = nLen;
+		Qs_s = (int*)malloc(sizeof(int) * 2 * Tams);
+	}
+
+	memset(Qs_s, 0, nLen * 2 * sizeof(int));
+
 	if (nInterpolation < 3) {
 
-		INT16 *pDest = pBurnSoundOut + (nPos << 1);
-		for (INT32 i = 0; i < nLen; i++) {
-			INT32 nLeftSample = 0, nRightSample = 0;
-			INT32 nLeftOut = 0, nRightOut = 0;
+		// Go through all channels
+		for (int c = 0; c < 16; c++) {
 
-			nDelta += CalcAdvance();
-			while(nDelta > 0xfff)
-			{
-				interpolate_buffer[0][0] = chip.out[0];
-				interpolate_buffer[1][0] = chip.out[1];
+			// If the channel is playing, add the samples to the buffer
+			if (QChan[c].bKey) {
+				int VolL = (QChan[c].nMasterVolume * QChan[c].nVolume[0]) >> nQscVolumeShift;
+				int VolR = (QChan[c].nMasterVolume * QChan[c].nVolume[1]) >> nQscVolumeShift;
+				int* pTemp = Qs_s;
+				int i = nLen;
+				int s, p;
 
-				update_sample();
-				nDelta -= 0x1000;
+				if (QChan[c].bKey & 2) {
+					QChan[c].bKey &= ~2;
+					QChan[c].nPos = QChan[c].nPlayStart;
+				}
+
+				while (i--) {
+
+					p = (QChan[c].nPos >> 12) & 0xFFFF;
+
+					// Check for end of sample
+					if (QChan[c].nPos >= (QChan[c].nEnd - 0x01000)) {
+						if (QChan[c].nLoop) {						// Loop sample
+							if (QChan[c].nPos < QChan[c].nEnd) {
+								QChan[c].nEndBuffer[0] = QChan[c].PlayBank[(QChan[c].nEnd - QChan[c].nLoop) >> 12];
+							} else {
+								QChan[c].nPos = QChan[c].nEnd - QChan[c].nLoop + (QChan[c].nPos & 0x0FFF);
+								p = (QChan[c].nPos >> 12) & 0xFFFF;
+							}
+						} else {
+							if (QChan[c].nPos < QChan[c].nEnd) {
+								QChan[c].nEndBuffer[0] = QChan[c].PlayBank[p];
+							} else {
+								QChan[c].bKey = 0;					// Quit playing
+								break;
+							}
+						}
+					} else {
+						QChan[c].nEndBuffer[0] = QChan[c].PlayBank[p + 1];
+					}
+
+					// Interpolate sample
+					s = QChan[c].PlayBank[p] * (1 << 6) + ((QChan[c].nPos) & ((1 << 12) - 1)) * (QChan[c].nEndBuffer[0] - QChan[c].PlayBank[p]) / (1 << 6);
+
+					// Add to the sound currently in the buffer
+					pTemp[0] += s * VolL;
+					pTemp[1] += s * VolR;
+
+					pTemp += 2;
+
+					QChan[c].nPos += QChan[c].nAdvance;				// increment sample position based on pitch
+				}
 			}
-
-			nLeftOut = interpolate_buffer[0][0] + (((chip.out[0] - interpolate_buffer[0][0]) * nDelta) >> 12);
-			nRightOut = interpolate_buffer[1][0] + (((chip.out[1] - interpolate_buffer[1][0]) * nDelta) >> 12);
-
-			if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_1] & BURN_SND_ROUTE_LEFT) == BURN_SND_ROUTE_LEFT) {
-				nLeftSample += (INT32)(nLeftOut * QsndGain[BURN_SND_QSND_OUTPUT_1]);
-			}
-			if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_1] & BURN_SND_ROUTE_RIGHT) == BURN_SND_ROUTE_RIGHT) {
-				nRightSample += (INT32)(nLeftOut * QsndGain[BURN_SND_QSND_OUTPUT_1]);
-			}
-
-			if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_2] & BURN_SND_ROUTE_LEFT) == BURN_SND_ROUTE_LEFT) {
-				nLeftSample += (INT32)(nRightOut * QsndGain[BURN_SND_QSND_OUTPUT_2]);
-			}
-			if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_2] & BURN_SND_ROUTE_RIGHT) == BURN_SND_ROUTE_RIGHT) {
-				nRightSample += (INT32)(nRightOut * QsndGain[BURN_SND_QSND_OUTPUT_2]);
-			}
-
-			pDest[(i << 1) + 0] = BURN_SND_CLIP(nLeftSample);
-			pDest[(i << 1) + 1] = BURN_SND_CLIP(nRightSample);
 		}
+
+#ifdef BUILD_X86_ASM
+		if (bBurnUseMMX) {
+			BurnSoundCopyClamp_A(Qs_s, pBurnSoundOut + (nPos << 1), nLen);
+		} else {
+#endif
+			BurnSoundCopyClamp_C(Qs_s, pBurnSoundOut + (nPos << 1), nLen);
+#ifdef BUILD_X86_ASM
+		}
+#endif
 		nPos = nEnd;
 
 		return 0;
 	}
 
-	INT16 *pDest = pBurnSoundOut + (nPos << 1);
-	for (INT32 i = 0; i < nLen; i++) {
-		INT32 nLeftSample = 0, nRightSample = 0;
-		INT32 nLeftOut = 0, nRightOut = 0;
+	// Go through all channels
+	for (int c = 0; c < 16; c++) {
 
-		nDelta += CalcAdvance();
-		while(nDelta > 0xfff)
-		{
-			update_sample();
-			interpolate_buffer[0][0] = interpolate_buffer[0][1];
-			interpolate_buffer[1][0] = interpolate_buffer[1][1];
-			interpolate_buffer[0][1] = interpolate_buffer[0][2];
-			interpolate_buffer[1][1] = interpolate_buffer[1][2];
-			interpolate_buffer[0][2] = interpolate_buffer[0][3];
-			interpolate_buffer[1][2] = interpolate_buffer[1][3];
-			interpolate_buffer[0][3] = chip.out[0];
-			interpolate_buffer[1][3] = chip.out[1];
-			nDelta -= 0x1000;
-		}
+		// If the channel is playing, add the samples to the buffer
+		if (QChan[c].bKey) {
+			int VolL = (QChan[c].nMasterVolume * QChan[c].nVolume[0]) >> nQscVolumeShift;
+			int VolR = (QChan[c].nMasterVolume * QChan[c].nVolume[1]) >> nQscVolumeShift;
+			int* pTemp = Qs_s;
+			int i = nLen;
 
-		nLeftOut = INTERPOLATE4PS_16BIT(nDelta,
-								  interpolate_buffer[0][0],
-								  interpolate_buffer[0][1],
-								  interpolate_buffer[0][2],
-								  interpolate_buffer[0][3]);
-		nRightOut = INTERPOLATE4PS_16BIT(nDelta,
-								  interpolate_buffer[1][0],
-								  interpolate_buffer[1][1],
-								  interpolate_buffer[1][2],
-								  interpolate_buffer[1][3]);
+			// handle 1st sample
+			if (QChan[c].bKey & 2) {
+				while (QChan[c].nPos < 0x1000 && i) {
+					int p = QChan[c].nPlayStart >> 12;
+					int s = INTERPOLATE4PS_CUSTOM(QChan[c].nPos,
+												  0,
+												  QChan[c].PlayBank[p + 0],
+												  QChan[c].PlayBank[p + 1],
+												  QChan[c].PlayBank[p + 2],
+												  256);
 
-		if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_1] & BURN_SND_ROUTE_LEFT) == BURN_SND_ROUTE_LEFT) {
-			nLeftSample += (INT32)(nLeftOut * QsndGain[BURN_SND_QSND_OUTPUT_1]);
-		}
-		if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_1] & BURN_SND_ROUTE_RIGHT) == BURN_SND_ROUTE_RIGHT) {
-			nRightSample += (INT32)(nLeftOut * QsndGain[BURN_SND_QSND_OUTPUT_1]);
-		}
+					pTemp[0] += s * VolL;
+					pTemp[1] += s * VolR;
 
-		if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_2] & BURN_SND_ROUTE_LEFT) == BURN_SND_ROUTE_LEFT) {
-			nLeftSample += (INT32)(nRightOut * QsndGain[BURN_SND_QSND_OUTPUT_2]);
-		}
-		if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_2] & BURN_SND_ROUTE_RIGHT) == BURN_SND_ROUTE_RIGHT) {
-			nRightSample += (INT32)(nRightOut * QsndGain[BURN_SND_QSND_OUTPUT_2]);
-		}
+					QChan[c].nPos += QChan[c].nAdvance;				// increment sample position based on pitch
 
-		pDest[(i << 1) + 0] = BURN_SND_CLIP(nLeftSample);
-		pDest[(i << 1) + 1] = BURN_SND_CLIP(nRightSample);
+					pTemp += 2;
+					i--;
+				}
+				if (i > 0) {
+					QChan[c].bKey &= ~2;
+					QChan[c].nPos = (QChan[c].nPos & 0x0FFF) + QChan[c].nPlayStart;
+				}
+			}
+
+#ifdef BUILD_X86_ASM
+			if (bBurnUseMMX && i > 0) {
+				QChan[c].bKey = (unsigned char)ChannelMix_QS_A(pTemp, i,
+															   QChan[c].PlayBank,
+															   QChan[c].nEnd,
+															   &(QChan[c].nPos),
+															   VolL,
+															   VolR,
+															   QChan[c].nLoop,
+															   QChan[c].nAdvance,
+															   QChan[c].nEndBuffer);
+			} else {
+#endif
+				while (i > 0) {
+					int s, p;
+
+					// Check for end of sample
+					if (QChan[c].nPos >= (QChan[c].nEnd - 0x3000)) {
+						if (QChan[c].nPos < QChan[c].nEnd) {
+							int nIndex = 4 - ((QChan[c].nEnd - QChan[c].nPos) >> 12);
+							s = INTERPOLATE4PS_CUSTOM((QChan[c].nPos) & ((1 << 12) - 1),
+													  QChan[c].nEndBuffer[nIndex + 0],
+													  QChan[c].nEndBuffer[nIndex + 1],
+													  QChan[c].nEndBuffer[nIndex + 2],
+													  QChan[c].nEndBuffer[nIndex + 3],
+													  256);
+						} else {
+							if (QChan[c].nLoop) {					// Loop sample
+								if (QChan[c].nLoop <= 0x1000) {		// Don't play, but leave bKey on
+									QChan[c].nPos = QChan[c].nEnd - 0x1000;
+									break;
+								}
+								QChan[c].nPos -= QChan[c].nLoop;
+								continue;
+							} else {
+								QChan[c].bKey = 0;					// Stop playing
+								break;
+							}
+						}
+					} else {
+						p = (QChan[c].nPos >> 12) & 0xFFFF;
+						s = INTERPOLATE4PS_CUSTOM((QChan[c].nPos) & ((1 << 12) - 1),
+												  QChan[c].PlayBank[p + 0],
+												  QChan[c].PlayBank[p + 1],
+												  QChan[c].PlayBank[p + 2],
+												  QChan[c].PlayBank[p + 3],
+												  256);
+					}
+
+					// Add to the sound currently in the buffer
+					pTemp[0] += s * VolL;
+					pTemp[1] += s * VolR;
+
+					pTemp += 2;
+
+					QChan[c].nPos += QChan[c].nAdvance;				// increment sample position based on pitch
+
+					i--;
+				}
+#ifdef BUILD_X86_ASM
+			}
+#endif
+		}
 	}
+
+#ifdef BUILD_X86_ASM
+	if (bBurnUseMMX) {
+		BurnSoundCopyClamp_A(Qs_s, pBurnSoundOut + (nPos << 1), nLen);
+	} else {
+#endif
+		BurnSoundCopyClamp_C(Qs_s, pBurnSoundOut + (nPos << 1), nLen);
+#ifdef BUILD_X86_ASM
+	}
+#endif
 	nPos = nEnd;
 
 	return 0;

--- a/src/burn/capcom/qs_c.cpp
+++ b/src/burn/capcom/qs_c.cpp
@@ -84,7 +84,7 @@ static void UpdateEndBuffer(struct QChan* pc)
 static void CalcAdvance(struct QChan* pc)
 {
 	if (nQscRate) {
-		pc->nAdvance = (INT64)pc->nPitch * nQscClock / nQscClockDivider / nQscRate;
+		pc->nAdvance = (long long)pc->nPitch * nQscClock / nQscClockDivider / nQscRate;
 	}
 }
 
@@ -102,7 +102,7 @@ void QscExit()
 {
 	nQscRate = 0;
 
-	BurnFree(Qs_s);
+	free(Qs_s);
 	Tams = -1;
 }
 
@@ -272,9 +272,9 @@ INT32 QscUpdate(INT32 nEnd)
 	}
 
 	if (Tams < nLen) {
-		BurnFree(Qs_s);
+		free(Qs_s);
 		Tams = nLen;
-		Qs_s = (INT32*)BurnMalloc(sizeof(INT32) * 2 * Tams);
+		Qs_s = (INT32*)malloc(sizeof(INT32) * 2 * Tams);
 	}
 
 	memset(Qs_s, 0, nLen * 2 * sizeof(INT32));

--- a/src/burn/capcom/qs_c.cpp
+++ b/src/burn/capcom/qs_c.cpp
@@ -106,7 +106,7 @@ void QscExit()
 	Tams = -1;
 }
 
-INT32 QscInit(INT32 nRate)
+int QscInit(int nRate, int nVolumeShift)
 {
 	nQscRate = nRate;
 

--- a/src/burn/capcom/qs_c_neo.cpp
+++ b/src/burn/capcom/qs_c_neo.cpp
@@ -1,0 +1,920 @@
+/*
+
+	Capcom DL-1425 QSound emulator
+	==============================
+
+	by superctr (Ian Karlsson)
+	with thanks to Valley Bell
+
+	2018-05-12 - 2018-05-15
+
+*/
+
+#include <math.h>
+#include <stddef.h>
+#include <string.h>	// for memset
+#include "cps.h"
+#include "burn_sound.h"
+
+static const INT32 nQscClock = 60000000;
+static const INT32 nQscClockDivider = 2496;
+
+static INT32 nQscRate = 0;
+//static float nQscVolumeShift;
+
+static INT32 nPos;
+static INT32 nDelta;
+
+static double QsndGain[2];
+static INT32 QsndOutputDir[2];
+
+#define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
+
+struct qsound_voice {
+	UINT16 bank;
+	INT16 addr; // top word is the sample address
+	UINT16 phase;
+	UINT16 rate;
+	INT16 loop_len;
+	INT16 end_addr;
+	INT16 volume;
+	INT16 echo;
+};
+
+struct qsound_adpcm {
+	UINT16 start_addr;
+	UINT16 end_addr;
+	UINT16 bank;
+	INT16 volume;
+	UINT16 flag;
+	INT16 cur_vol;
+	INT16 step_size;
+	UINT16 cur_addr;
+};
+
+// Q1 Filter
+struct qsound_fir {
+	int tap_count;	// usually 95
+	int delay_pos;
+	INT16 table_pos;
+	INT16 taps[95];
+	INT16 delay_line[95];
+};
+
+// Delay line
+struct qsound_delay {
+	INT16 delay;
+	INT16 volume;
+	INT16 write_pos;
+	INT16 read_pos;
+	INT16 delay_line[51];
+};
+
+struct qsound_echo {
+	UINT16 end_pos;
+
+	INT16 feedback;
+	INT16 length;
+	INT16 last_sample;
+	INT16 delay_line[1024];
+	INT16 delay_pos;
+};
+
+struct qsound_chip {
+	INT16 out[2];
+
+	struct qsound_voice voice[16];
+	struct qsound_adpcm adpcm[3];
+
+	UINT16 voice_pan[16+3];
+	INT16 voice_output[16+3];
+
+	struct qsound_echo echo;
+
+	struct qsound_fir filter[2];
+	struct qsound_fir alt_filter[2];
+
+	struct qsound_delay wet[2];
+	struct qsound_delay dry[2];
+
+	UINT16 state;
+	UINT16 next_state;
+
+	UINT16 delay_update;
+
+	int state_counter;
+	UINT8 ready_flag;
+};
+
+static UINT16 *register_map[256];
+static INT16 pan_tables[2][2][98];
+
+static INT16 interpolate_buffer[2][4];
+
+static void init_pan_tables();
+static void init_register_map();
+static void update_sample();
+
+static void state_init();
+static void state_refresh_filter_1();
+static void state_refresh_filter_2();
+static void state_normal_update();
+
+static inline INT16 get_sample(UINT16 bank,UINT16 address);
+static inline const INT16* get_filter_table(UINT16 offset);
+static inline INT16 pcm_update(int voice_no, INT32 *echo_out);
+static inline void adpcm_update(int voice_no, int nibble);
+static inline INT16 echo(struct qsound_echo *r,INT32 input);
+static inline INT32 fir(struct qsound_fir *f, INT16 input);
+static inline INT32 delay(struct qsound_delay *d, INT32 input);
+static inline void delay_update(struct qsound_delay *d);
+
+static qsound_chip chip;
+
+static const INT16 qsound_dry_mix_table[33] = {
+	-16384,-16384,-16384,-16384,-16384,-16384,-16384,-16384,
+	-16384,-16384,-16384,-16384,-16384,-16384,-16384,-16384,
+	-16384,-14746,-13107,-11633,-10486,-9175,-8520,-7209,
+	-6226,-5226,-4588,-3768,-3277,-2703,-2130,-1802,
+	0
+};
+
+static const INT16 qsound_wet_mix_table[33] = {
+	0,-1638,-1966,-2458,-2949,-3441,-4096,-4669,
+	-4915,-5120,-5489,-6144,-7537,-8831,-9339,-9830,
+	-10240,-10322,-10486,-10568,-10650,-11796,-12288,-12288,
+	-12534,-12648,-12780,-12829,-12943,-13107,-13418,-14090,
+	-16384
+};
+
+static const INT16 qsound_linear_mix_table[33] = {
+	-16379,-16338,-16257,-16135,-15973,-15772,-15531,-15251,
+	-14934,-14580,-14189,-13763,-13303,-12810,-12284,-11729,
+	-11729,-11144,-10531,-9893,-9229,-8543,-7836,-7109,
+	-6364,-5604,-4829,-4043,-3246,-2442,-1631,-817,
+	0
+};
+
+static const INT16 qsound_filter_data[5][95] = {
+	{	// d53 - 0
+		0,0,0,6,44,-24,-53,-10,59,-40,-27,1,39,-27,56,127,174,36,-13,49,
+		212,142,143,-73,-20,66,-108,-117,-399,-265,-392,-569,-473,-71,95,-319,-218,-230,331,638,
+		449,477,-180,532,1107,750,9899,3828,-2418,1071,-176,191,-431,64,117,-150,-274,-97,-238,165,
+		166,250,-19,4,37,204,186,-6,140,-77,-1,1,18,-10,-151,-149,-103,-9,55,23,
+		-102,-97,-11,13,-48,-27,5,18,-61,-30,64,72,0,0,0,
+	},
+	{	// db2 - 1 - default left filter
+		0,0,0,85,24,-76,-123,-86,-29,-14,-20,-7,6,-28,-87,-89,-5,100,154,160,
+		150,118,41,-48,-78,-23,59,83,-2,-176,-333,-344,-203,-66,-39,2,224,495,495,280,
+		432,1340,2483,5377,1905,658,0,97,347,285,35,-95,-78,-82,-151,-192,-171,-149,-147,-113,
+		-22,71,118,129,127,110,71,31,20,36,46,23,-27,-63,-53,-21,-19,-60,-92,-69,
+		-12,25,29,30,40,41,29,30,46,39,-15,-74,0,0,0,
+	},
+	{	// e11 - 2 - default right filter
+		0,0,0,23,42,47,29,10,2,-14,-54,-92,-93,-70,-64,-77,-57,18,94,113,
+		87,69,67,50,25,29,58,62,24,-39,-131,-256,-325,-234,-45,58,78,223,485,496,
+		127,6,857,2283,2683,4928,1328,132,79,314,189,-80,-90,35,-21,-186,-195,-99,-136,-258,
+		-189,82,257,185,53,41,84,68,38,63,77,14,-60,-71,-71,-120,-151,-84,14,29,
+		-8,7,66,69,12,-3,54,92,52,-6,-15,-2,0,0,0,
+	},
+	{	// e70 - 3
+		0,0,0,2,-28,-37,-17,0,-9,-22,-3,35,52,39,20,7,-6,2,55,121,
+		129,67,8,1,9,-6,-16,16,66,96,118,130,75,-47,-92,43,223,239,151,219,
+		440,475,226,206,940,2100,2663,4980,865,49,-33,186,231,103,42,114,191,184,116,29,
+		-47,-72,-21,60,96,68,31,32,63,87,76,39,7,14,55,85,67,18,-12,-3,
+		21,34,29,6,-27,-49,-37,-2,16,0,-21,-16,0,0,0,
+	},
+	{	// ecf - 4
+		0,0,0,48,7,-22,-29,-10,24,54,59,29,-36,-117,-185,-213,-185,-99,13,90,
+		83,24,-5,23,53,47,38,56,67,57,75,107,16,-242,-440,-355,-120,-33,-47,152,
+		501,472,-57,-292,544,1937,2277,6145,1240,153,47,200,152,36,64,134,74,-82,-208,-266,
+		-268,-188,-42,65,74,56,89,133,114,44,-3,-1,17,29,29,-2,-76,-156,-187,-151,
+		-85,-31,-5,7,20,32,24,-5,-20,6,48,62,0,0,0,
+	}
+};
+
+static const INT16 qsound_filter_data2[209] = {
+	// f2e - following 95 values used for "disable output" filter
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,0,0,
+
+	// f73 - following 45 values used for "mode 2" filter (overlaps with f2e)
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,
+	-371,-196,-268,-512,-303,-315,-184,-76,276,-256,298,196,990,236,1114,-126,4377,6549,791,
+
+	// fa0 - filtering disabled (for 95-taps) (use fa3 or fa4 for mode2 filters)
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,-16384,0,0,0,0,0,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+};
+
+static const INT16 adpcm_step_table[16] = {
+	154, 154, 128, 102, 77, 58, 58, 58,
+	58, 58, 58, 58, 77, 102, 128, 154
+};
+
+// DSP states
+enum {
+	STATE_INIT1		= 0x288,
+	STATE_INIT2		= 0x61a,
+	STATE_REFRESH1	= 0x039,
+	STATE_REFRESH2	= 0x04f,
+	STATE_NORMAL1	= 0x314,
+	STATE_NORMAL2 	= 0x6b2
+};
+
+enum {
+	PANTBL_LEFT		= 0,
+	PANTBL_RIGHT	= 1,
+	PANTBL_DRY		= 0,
+	PANTBL_WET		= 1
+};
+
+static void init_pan_tables()
+{
+	int i;
+	for(i=0;i<33;i++)
+	{
+		// dry mixing levels
+		pan_tables[PANTBL_LEFT][PANTBL_DRY][i] = qsound_dry_mix_table[i];
+		pan_tables[PANTBL_RIGHT][PANTBL_DRY][i] = qsound_dry_mix_table[32-i];
+		// wet mixing levels
+		pan_tables[PANTBL_LEFT][PANTBL_WET][i] = qsound_wet_mix_table[i];
+		pan_tables[PANTBL_RIGHT][PANTBL_WET][i] = qsound_wet_mix_table[32-i];
+		// linear panning, only for dry component. wet component is muted.
+		pan_tables[PANTBL_LEFT][PANTBL_DRY][i+0x30] = qsound_linear_mix_table[i];
+		pan_tables[PANTBL_RIGHT][PANTBL_DRY][i+0x30] = qsound_linear_mix_table[32-i];
+	}
+}
+
+static void init_register_map()
+{
+	int i;
+
+	// unused registers
+	for(i=0;i<256;i++)
+		register_map[i] = NULL;
+
+	// PCM registers
+	for(i=0;i<16;i++) // PCM voices
+	{
+		register_map[(i<<3)+0] = (UINT16*)&chip.voice[(i+1)%16].bank; // Bank applies to the next channel
+		register_map[(i<<3)+1] = (UINT16*)&chip.voice[i].addr; // Current sample position and start position.
+		register_map[(i<<3)+2] = (UINT16*)&chip.voice[i].rate; // 4.12 fixed point decimal.
+		register_map[(i<<3)+3] = (UINT16*)&chip.voice[i].phase;
+		register_map[(i<<3)+4] = (UINT16*)&chip.voice[i].loop_len;
+		register_map[(i<<3)+5] = (UINT16*)&chip.voice[i].end_addr;
+		register_map[(i<<3)+6] = (UINT16*)&chip.voice[i].volume;
+		register_map[(i<<3)+7] = NULL;	// unused
+		register_map[i+0x80] = (UINT16*)&chip.voice_pan[i];
+		register_map[i+0xba] = (UINT16*)&chip.voice[i].echo;
+	}
+
+	// ADPCM registers
+	for(i=0;i<3;i++) // ADPCM voices
+	{
+		// ADPCM sample rate is fixed to 8khz. (one channel is updated every third sample)
+		register_map[(i<<2)+0xca] = (UINT16*)&chip.adpcm[i].start_addr;
+		register_map[(i<<2)+0xcb] = (UINT16*)&chip.adpcm[i].end_addr;
+		register_map[(i<<2)+0xcc] = (UINT16*)&chip.adpcm[i].bank;
+		register_map[(i<<2)+0xcd] = (UINT16*)&chip.adpcm[i].volume;
+		register_map[i+0xd6] = (UINT16*)&chip.adpcm[i].flag; // non-zero to start ADPCM playback
+		register_map[i+0x90] = (UINT16*)&chip.voice_pan[16+i];
+	}
+
+	// QSound registers
+	register_map[0x93] = (UINT16*)&chip.echo.feedback;
+	register_map[0xd9] = (UINT16*)&chip.echo.end_pos;
+	register_map[0xe2] = (UINT16*)&chip.delay_update; // non-zero to update delays
+	register_map[0xe3] = (UINT16*)&chip.next_state;
+	for(i=0;i<2;i++)  // left, right
+	{
+		// Wet
+		register_map[(i<<1)+0xda] = (UINT16*)&chip.filter[i].table_pos;
+		register_map[(i<<1)+0xde] = (UINT16*)&chip.wet[i].delay;
+		register_map[(i<<1)+0xe4] = (UINT16*)&chip.wet[i].volume;
+		// Dry
+		register_map[(i<<1)+0xdb] = (UINT16*)&chip.alt_filter[i].table_pos;
+		register_map[(i<<1)+0xdf] = (UINT16*)&chip.dry[i].delay;
+		register_map[(i<<1)+0xe5] = (UINT16*)&chip.dry[i].volume;
+	}
+}
+
+inline INT16 get_sample(UINT16 bank, UINT16 address)
+{
+	UINT32 rom_addr;
+	UINT32 rom_mask = 0;
+	UINT8 sample_data;
+
+	if(nCpsQSamLen)
+		rom_mask = nCpsQSamLen - 1;
+
+	if (! rom_mask)
+		return 0;	// no ROM loaded
+	if (! (bank & 0x8000))
+		return 0;	// ignore attempts to read from DSP program ROM
+
+	bank &= 0x7FFF;
+	rom_addr = (bank << 16) | (address << 0);
+
+	sample_data = CpsQSam[rom_addr & rom_mask];
+
+	return (INT16)((sample_data << 8) & 0xff00);
+}
+
+static inline const INT16* get_filter_table(UINT16 offset)
+{
+	int index;
+
+	if (offset >= 0xf2e && offset < 0xfff)
+		return &qsound_filter_data2[offset-0xf2e];	// overlapping filter data
+
+	index = (offset-0xd53)/95;
+	if(index >= 0 && index < 5)
+		return qsound_filter_data[index];	// normal tables
+
+	return NULL;	// no filter found.
+}
+
+/********************************************************************/
+
+// updates one DSP sample
+static void update_sample()
+{
+	switch(chip.state)
+	{
+		default:
+		case STATE_INIT1:
+		case STATE_INIT2:
+			state_init();
+			return;
+		case STATE_REFRESH1:
+			state_refresh_filter_1();
+			return;
+		case STATE_REFRESH2:
+			state_refresh_filter_2();
+			return;
+		case STATE_NORMAL1:
+		case STATE_NORMAL2:
+			state_normal_update();
+			return;
+	}
+}
+
+// Initialization routine
+static void state_init()
+{
+	int mode = (chip.state == STATE_INIT2) ? 1 : 0;
+	int i;
+
+	// we're busy for 4 samples, including the filter refresh.
+	if(chip.state_counter >= 2)
+	{
+		chip.state_counter = 0;
+		chip.state = chip.next_state;
+		return;
+	}
+	else if(chip.state_counter == 1)
+	{
+		chip.state_counter++;
+		return;
+	}
+
+	memset(chip.voice, 0, sizeof(chip.voice));
+	memset(chip.adpcm, 0, sizeof(chip.adpcm));
+	memset(chip.filter, 0, sizeof(chip.filter));
+	memset(chip.alt_filter, 0, sizeof(chip.alt_filter));
+	memset(chip.wet, 0, sizeof(chip.wet));
+	memset(chip.dry, 0, sizeof(chip.dry));
+	memset(&chip.echo, 0, sizeof(chip.echo));
+
+	for(i=0;i<19;i++)
+	{
+		chip.voice_pan[i] = 0x120;
+		chip.voice_output[i] = 0;
+	}
+
+	for(i=0;i<16;i++)
+		chip.voice[i].bank = 0x8000;
+	for(i=0;i<3;i++)
+		chip.adpcm[i].bank = 0x8000;
+
+	if(mode == 0)
+	{
+		// mode 1
+		chip.wet[0].delay = 0;
+		chip.dry[0].delay = 46;
+		chip.wet[1].delay = 0;
+		chip.dry[1].delay = 48;
+		chip.filter[0].table_pos = 0xdb2;
+		chip.filter[1].table_pos = 0xe11;
+		chip.echo.end_pos = 0x554 + 6;
+		chip.next_state = STATE_REFRESH1;
+	}
+	else
+	{
+		// mode 2
+		chip.wet[0].delay = 1;
+		chip.dry[0].delay = 0;
+		chip.wet[1].delay = 0;
+		chip.dry[1].delay = 0;
+		chip.filter[0].table_pos = 0xf73;
+		chip.filter[1].table_pos = 0xfa4;
+		chip.alt_filter[0].table_pos = 0xf73;
+		chip.alt_filter[1].table_pos = 0xfa4;
+		chip.echo.end_pos = 0x53c + 6;
+		chip.next_state = STATE_REFRESH2;
+	}
+
+	chip.wet[0].volume = 0x3fff;
+	chip.dry[0].volume = 0x3fff;
+	chip.wet[1].volume = 0x3fff;
+	chip.dry[1].volume = 0x3fff;
+
+	chip.delay_update = 1;
+	chip.ready_flag = 0;
+	chip.state_counter = 1;
+}
+
+// Updates filter parameters for mode 1
+static void state_refresh_filter_1()
+{
+	const INT16 *table;
+	int ch;
+
+	for(ch=0; ch<2; ch++)
+	{
+		chip.filter[ch].delay_pos = 0;
+		chip.filter[ch].tap_count = 95;
+
+		table = get_filter_table(chip.filter[ch].table_pos);
+		if (table != NULL)
+			memcpy(chip.filter[ch].taps, table, 95 * sizeof(INT16));
+	}
+
+	chip.state = chip.next_state = STATE_NORMAL1;
+}
+
+// Updates filter parameters for mode 2
+static void state_refresh_filter_2()
+{
+	const INT16 *table;
+	int ch;
+
+	for(ch=0; ch<2; ch++)
+	{
+		chip.filter[ch].delay_pos = 0;
+		chip.filter[ch].tap_count = 45;
+
+		table = get_filter_table(chip.filter[ch].table_pos);
+		if (table != NULL)
+			memcpy(chip.filter[ch].taps, table, 45 * sizeof(INT16));
+
+		chip.alt_filter[ch].delay_pos = 0;
+		chip.alt_filter[ch].tap_count = 44;
+
+		table = get_filter_table(chip.alt_filter[ch].table_pos);
+		if (table != NULL)
+			memcpy(chip.alt_filter[ch].taps, table, 44 * sizeof(INT16));
+	}
+
+	chip.state = chip.next_state = STATE_NORMAL2;
+}
+
+// Updates a PCM voice. There are 16 voices, each are updated every sample
+// with full rate and volume control.
+static inline INT16 pcm_update(int voice_no, INT32 *echo_out)
+{
+	struct qsound_voice *v = &chip.voice[voice_no];
+	INT32 new_phase;
+	INT16 output;
+
+	// Read sample from rom and apply volume
+	output = (v->volume * get_sample(v->bank, v->addr))>>14;
+
+	*echo_out += (output * v->echo)<<2;
+
+	// Add delta to the phase and loop back if required
+	new_phase = v->rate + ((v->addr<<12) | (v->phase>>4));
+
+	if((new_phase>>12) >= v->end_addr)
+		new_phase -= (v->loop_len<<12);
+
+	new_phase = CLAMP(new_phase, -0x8000000, 0x7FFFFFF);
+	v->addr = new_phase>>12;
+	v->phase = (new_phase<<4)&0xffff;
+
+	return output;
+}
+
+// Updates an ADPCM voice. There are 3 voices, one is updated every sample
+// (effectively making the ADPCM rate 1/3 of the master sample rate), and
+// volume is set when starting samples only.
+// The ADPCM algorithm is supposedly similar to Yamaha ADPCM. It also seems
+// like Capcom never used it, so this was not emulated in the earlier QSound
+// emulators.
+static inline void adpcm_update(int voice_no, int nibble)
+{
+	struct qsound_adpcm *v = &chip.adpcm[voice_no];
+
+	INT32 delta;
+	INT8 step;
+
+	if(!nibble)
+	{
+		// Mute voice when it reaches the end address.
+		if(v->cur_addr == v->end_addr)
+			v->cur_vol = 0;
+
+		// Playback start flag
+		if(v->flag)
+		{
+			chip.voice_output[16+voice_no] = 0;
+			v->flag = 0;
+			v->step_size = 10;
+			v->cur_vol = v->volume;
+			v->cur_addr = v->start_addr;
+		}
+
+		// get top nibble
+		step = get_sample(v->bank, v->cur_addr) >> 8;
+	}
+	else
+	{
+		// get bottom nibble
+		step = get_sample(v->bank, v->cur_addr++) >> 4;
+	}
+
+	// shift with sign extend
+	step >>= 4;
+
+	// delta = (0.5 + abs(v->step)) * v->step_size
+	delta = ((1+abs(step<<1)) * v->step_size)>>1;
+	if(step <= 0)
+		delta = -delta;
+	delta += chip.voice_output[16+voice_no];
+	delta = CLAMP(delta,-32768,32767);
+
+	chip.voice_output[16+voice_no] = (delta * v->cur_vol)>>16;
+
+	v->step_size = (adpcm_step_table[8+step] * v->step_size) >> 6;
+	v->step_size = CLAMP(v->step_size, 1, 2000);
+}
+
+// The echo effect is pretty simple. A moving average filter is used on
+// the output from the delay line to smooth samples over time.
+static inline INT16 echo(struct qsound_echo *r,INT32 input)
+{
+	// get average of last 2 samples from the delay line
+	INT32 new_sample;
+	INT32 old_sample = r->delay_line[r->delay_pos];
+	INT32 last_sample = r->last_sample;
+
+	r->last_sample = old_sample;
+	old_sample = (old_sample+last_sample) >> 1;
+
+	// add current sample to the delay line
+	new_sample = input + ((old_sample * r->feedback)<<2);
+	r->delay_line[r->delay_pos++] = new_sample>>16;
+
+	if(r->delay_pos >= r->length)
+		r->delay_pos = 0;
+
+	return old_sample;
+}
+
+// Process a sample update
+static void state_normal_update()
+{
+	int v, ch;
+	INT32 echo_input = 0;
+	INT16 echo_output;
+
+	chip.ready_flag = 0x80;
+
+	// recalculate echo length
+	if(chip.state == STATE_NORMAL2)
+		chip.echo.length = chip.echo.end_pos - 0x53c;
+	else
+		chip.echo.length = chip.echo.end_pos - 0x554;
+
+	chip.echo.length = CLAMP(chip.echo.length, 0, 1024);
+
+	// update PCM voices
+	for(v=0; v<16; v++)
+		chip.voice_output[v] = pcm_update(v, &echo_input);
+
+	// update ADPCM voices (one every third sample)
+	adpcm_update(chip.state_counter % 3, chip.state_counter / 3);
+
+	echo_output = echo(&chip.echo,echo_input);
+
+	// now, we do the magic stuff
+	for(ch=0; ch<2; ch++)
+	{
+		// Echo is output on the unfiltered component of the left channel and
+		// the filtered component of the right channel.
+		INT32 wet = (ch == 1) ? echo_output<<14 : 0;
+		INT32 dry = (ch == 0) ? echo_output<<14 : 0;
+		INT32 output = 0;
+
+		for(v=0; v<19; v++)
+		{
+			UINT16 pan_index = chip.voice_pan[v]-0x110;
+			if(pan_index > 97)
+				pan_index = 97;
+
+			// Apply different volume tables on the dry and wet inputs.
+			dry -= (chip.voice_output[v] * pan_tables[ch][PANTBL_DRY][pan_index]);
+			wet -= (chip.voice_output[v] * pan_tables[ch][PANTBL_WET][pan_index]);
+		}
+
+		// Saturate accumulated voices
+		dry = CLAMP(dry, -0x1fffffff, 0x1fffffff) << 2;
+		wet = CLAMP(wet, -0x1fffffff, 0x1fffffff) << 2;
+
+		// Apply FIR filter on 'wet' input
+		wet = fir(&chip.filter[ch], wet >> 16);
+
+		// in mode 2, we do this on the 'dry' input too
+		if(chip.state == STATE_NORMAL2)
+			dry = fir(&chip.alt_filter[ch], dry >> 16);
+
+		// output goes through a delay line and attenuation
+		output = (delay(&chip.wet[ch], wet) + delay(&chip.dry[ch], dry));
+
+		// DSP round function
+		output = ((output + 0x2000) & ~0x3fff) >> 14;
+		chip.out[ch] = CLAMP(output, -0x7fff, 0x7fff);
+
+		if(chip.delay_update)
+		{
+			delay_update(&chip.wet[ch]);
+			delay_update(&chip.dry[ch]);
+		}
+	}
+
+	chip.delay_update = 0;
+
+	// after 6 samples, the next state is executed.
+	chip.state_counter++;
+	if(chip.state_counter > 5)
+	{
+		chip.state_counter = 0;
+		chip.state = chip.next_state;
+	}
+}
+
+// Apply the FIR filter used as the Q1 transfer function
+static inline INT32 fir(struct qsound_fir *f, INT16 input)
+{
+	INT32 output = 0, tap = 0;
+
+	for(; tap < (f->tap_count-1); tap++)
+	{
+		output -= (f->taps[tap] * f->delay_line[f->delay_pos++])<<2;
+
+		if(f->delay_pos >= f->tap_count-1)
+			f->delay_pos = 0;
+	}
+
+	output -= (f->taps[tap] * input)<<2;
+
+	f->delay_line[f->delay_pos++] = input;
+	if(f->delay_pos >= f->tap_count-1)
+		f->delay_pos = 0;
+
+	return output;
+}
+
+// Apply delay line and component volume
+static inline INT32 delay(struct qsound_delay *d, INT32 input)
+{
+	INT32 output;
+
+	d->delay_line[d->write_pos++] = input>>16;
+	if(d->write_pos >= 51)
+		d->write_pos = 0;
+
+	output = d->delay_line[d->read_pos++]*d->volume;
+	if(d->read_pos >= 51)
+		d->read_pos = 0;
+
+	return output;
+}
+
+// Update the delay read position to match new delay length
+static inline void delay_update(struct qsound_delay *d)
+{
+	INT16 new_read_pos = (d->write_pos - d->delay) % 51;
+	if(new_read_pos < 0)
+		new_read_pos += 51;
+
+	d->read_pos = new_read_pos;
+}
+
+//==========================================
+
+static long long int CalcAdvance()
+{
+	if (nQscRate) {
+		return (long long int)0x1000 * nQscClock / nQscClockDivider / nQscRate;
+	}
+	return 0;
+}
+
+void QscReset()
+{
+	chip.ready_flag = 0;
+	chip.out[0] = chip.out[1] = 0;
+	chip.state = 0;
+	chip.state_counter = 0;
+	nDelta = 0;
+	memset(interpolate_buffer, 0, sizeof(interpolate_buffer));
+}
+
+void QscExit()
+{
+	nQscRate = 0;
+}
+
+INT32 QscInit(INT32 nRate, INT32 nVolumeShift)
+{
+	nQscRate = nRate;
+	nDelta = 0;
+
+	//nQscVolumeShift = (10 + nVolumeShift) / 10;
+
+	init_pan_tables();
+	init_register_map();
+
+	QsndGain[BURN_SND_QSND_OUTPUT_1] = 1.00;
+	QsndGain[BURN_SND_QSND_OUTPUT_2] = 1.00;
+	QsndOutputDir[BURN_SND_QSND_OUTPUT_1] = BURN_SND_ROUTE_LEFT;
+	QsndOutputDir[BURN_SND_QSND_OUTPUT_2] = BURN_SND_ROUTE_RIGHT;
+
+	QscReset();
+
+	return 0;
+}
+
+void QscSetRoute(INT32 nIndex, double nVolume, INT32 nRouteDir)
+{
+	QsndGain[nIndex] = nVolume;
+	QsndOutputDir[nIndex] = nRouteDir;
+}
+
+INT32 QscScan(INT32 nAction)
+{
+	struct BurnArea ba;
+	char szName[16];
+
+	sprintf(szName, "QSound");
+
+	ba.Data		= &chip;
+	ba.nLen		= STRUCT_SIZE_HELPER(struct qsound_chip, ready_flag);
+	ba.nAddress = 0;
+	ba.szName	= szName;
+	BurnAcb(&ba);
+
+	return 0;
+}
+
+void QscNewFrame()
+{
+	nPos = 0;
+}
+
+static inline void QscSyncQsnd()
+{
+	if (pBurnSoundOut) QscUpdate(ZetTotalCycles() * nBurnSoundLen / nCpsZ80Cycles);
+}
+
+void QscWrite(INT32 a, INT32 d)
+{
+	UINT16 *destination = register_map[a];
+	QscSyncQsnd();
+	if(destination)
+		*destination = d;
+	chip.ready_flag = 0;
+}
+
+UINT8 QscRead()
+{
+	QscSyncQsnd();
+	return chip.ready_flag;
+}
+
+INT32 QscUpdate(INT32 nEnd)
+{
+	INT32 nLen;
+
+	if (nEnd > nBurnSoundLen) {
+		nEnd = nBurnSoundLen;
+	}
+
+	nLen = nEnd - nPos;
+
+	if (nLen <= 0) {
+		return 0;
+	}
+
+	if (nInterpolation < 3) {
+
+		INT16 *pDest = pBurnSoundOut + (nPos << 1);
+		for (INT32 i = 0; i < nLen; i++) {
+			INT32 nLeftSample = 0, nRightSample = 0;
+			INT32 nLeftOut = 0, nRightOut = 0;
+
+			nDelta += CalcAdvance();
+			while(nDelta > 0xfff)
+			{
+				interpolate_buffer[0][0] = chip.out[0];
+				interpolate_buffer[1][0] = chip.out[1];
+
+				update_sample();
+				nDelta -= 0x1000;
+			}
+
+			nLeftOut = interpolate_buffer[0][0] + (((chip.out[0] - interpolate_buffer[0][0]) * nDelta) >> 12);
+			nRightOut = interpolate_buffer[1][0] + (((chip.out[1] - interpolate_buffer[1][0]) * nDelta) >> 12);
+
+			if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_1] & BURN_SND_ROUTE_LEFT) == BURN_SND_ROUTE_LEFT) {
+				nLeftSample += (INT32)(nLeftOut * QsndGain[BURN_SND_QSND_OUTPUT_1]);
+			}
+			if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_1] & BURN_SND_ROUTE_RIGHT) == BURN_SND_ROUTE_RIGHT) {
+				nRightSample += (INT32)(nLeftOut * QsndGain[BURN_SND_QSND_OUTPUT_1]);
+			}
+
+			if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_2] & BURN_SND_ROUTE_LEFT) == BURN_SND_ROUTE_LEFT) {
+				nLeftSample += (INT32)(nRightOut * QsndGain[BURN_SND_QSND_OUTPUT_2]);
+			}
+			if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_2] & BURN_SND_ROUTE_RIGHT) == BURN_SND_ROUTE_RIGHT) {
+				nRightSample += (INT32)(nRightOut * QsndGain[BURN_SND_QSND_OUTPUT_2]);
+			}
+
+			pDest[(i << 1) + 0] = BURN_SND_CLIP(nLeftSample);
+			pDest[(i << 1) + 1] = BURN_SND_CLIP(nRightSample);
+		}
+		nPos = nEnd;
+
+		return 0;
+	}
+
+	INT16 *pDest = pBurnSoundOut + (nPos << 1);
+	for (INT32 i = 0; i < nLen; i++) {
+		INT32 nLeftSample = 0, nRightSample = 0;
+		INT32 nLeftOut = 0, nRightOut = 0;
+
+		nDelta += CalcAdvance();
+		while(nDelta > 0xfff)
+		{
+			update_sample();
+			interpolate_buffer[0][0] = interpolate_buffer[0][1];
+			interpolate_buffer[1][0] = interpolate_buffer[1][1];
+			interpolate_buffer[0][1] = interpolate_buffer[0][2];
+			interpolate_buffer[1][1] = interpolate_buffer[1][2];
+			interpolate_buffer[0][2] = interpolate_buffer[0][3];
+			interpolate_buffer[1][2] = interpolate_buffer[1][3];
+			interpolate_buffer[0][3] = chip.out[0];
+			interpolate_buffer[1][3] = chip.out[1];
+			nDelta -= 0x1000;
+		}
+
+		nLeftOut = INTERPOLATE4PS_16BIT(nDelta,
+								  interpolate_buffer[0][0],
+								  interpolate_buffer[0][1],
+								  interpolate_buffer[0][2],
+								  interpolate_buffer[0][3]);
+		nRightOut = INTERPOLATE4PS_16BIT(nDelta,
+								  interpolate_buffer[1][0],
+								  interpolate_buffer[1][1],
+								  interpolate_buffer[1][2],
+								  interpolate_buffer[1][3]);
+
+		if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_1] & BURN_SND_ROUTE_LEFT) == BURN_SND_ROUTE_LEFT) {
+			nLeftSample += (INT32)(nLeftOut * QsndGain[BURN_SND_QSND_OUTPUT_1]);
+		}
+		if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_1] & BURN_SND_ROUTE_RIGHT) == BURN_SND_ROUTE_RIGHT) {
+			nRightSample += (INT32)(nLeftOut * QsndGain[BURN_SND_QSND_OUTPUT_1]);
+		}
+
+		if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_2] & BURN_SND_ROUTE_LEFT) == BURN_SND_ROUTE_LEFT) {
+			nLeftSample += (INT32)(nRightOut * QsndGain[BURN_SND_QSND_OUTPUT_2]);
+		}
+		if ((QsndOutputDir[BURN_SND_QSND_OUTPUT_2] & BURN_SND_ROUTE_RIGHT) == BURN_SND_ROUTE_RIGHT) {
+			nRightSample += (INT32)(nRightOut * QsndGain[BURN_SND_QSND_OUTPUT_2]);
+		}
+
+		pDest[(i << 1) + 0] = BURN_SND_CLIP(nLeftSample);
+		pDest[(i << 1) + 1] = BURN_SND_CLIP(nRightSample);
+	}
+	nPos = nEnd;
+
+	return 0;
+}

--- a/src/sdl-dingux/sdl_menu.cpp
+++ b/src/sdl-dingux/sdl_menu.cpp
@@ -188,7 +188,9 @@ void ShowMenu(MENU *menu)
 	// print info string
 	//DrawString("Press B to return to game", COLOR_HELP_TEXT, COLOR_BG, 56, 220);
 	DrawString("FinalBurn Alpha (" VERSION ")", COLOR_HELP_TEXT, COLOR_BG, 52, 2);
+#ifdef USE_QSOUND_FBNEO
 	DrawString("with QSound from FinalBurn Neo", COLOR_HELP_TEXT, COLOR_BG, 40, 12);
+#endif
 }
 
 /*


### PR DESCRIPTION
- [x] import src from fba-sdl
- [x] add macro to build new/old Qsound emulation